### PR TITLE
Add scripts for fetch / merge git workflow

### DIFF
--- a/scripts/fetch-rapids-repositories.sh
+++ b/scripts/fetch-rapids-repositories.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -Eeo pipefail
+
+cd $(dirname "$(realpath "$0")")/../../
+
+BASE_DIR="$(pwd)"
+
+CODE_REPOS="${CODE_REPOS:-rmm cudf cuml cugraph cuspatial}"
+ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks notebooks-contrib}"
+
+for REPO in $ALL_REPOS; do
+    cd "$BASE_DIR/$REPO";
+    git fetch upstream && git fetch origin;
+    cd - >/dev/null 2>&1;
+done

--- a/scripts/merge-rapids-repositories.sh
+++ b/scripts/merge-rapids-repositories.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -Eeo pipefail
+
+cd $(dirname "$(realpath "$0")")/../../
+
+BASE_DIR="$(pwd)"
+
+CODE_REPOS="${CODE_REPOS:-rmm cudf cuml cugraph cuspatial}"
+ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks notebooks-contrib}"
+
+for REPO in $ALL_REPOS; do
+    cd "$BASE_DIR/$REPO";
+    BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)";
+    while [ -z "$(git branch -r | grep upstream/$BRANCH_NAME)" ]; do
+        UPSTREAM_INFO="$(git remote -v show | grep upstream | head -n1)";
+        read -p "
+############################################################
+Branch \"$BRANCH_NAME\" not found in:
+${UPSTREAM_INFO}
+############################################################
+
+Please enter a branch name to merge (or leave empty to skip): " BRANCH_NAME </dev/tty
+    done
+    if [ -n "$BRANCH_NAME" ]; then
+        git merge upstream/"$BRANCH_NAME";
+        git submodule update --init --recursive;
+    else
+        echo -e "No alternate branch name supplied, skipping\n";
+    fi;
+    cd - >/dev/null 2>&1;
+done


### PR DESCRIPTION
My usual Git workflow involves a separate fetch and merge, rather than using `git pull` to incorporate upstream changes in one step - this enables me to see what upstream changes were since the last merge, before deciding whether to merge them into my local branches.

This commit adds scripts based on `pull-rapids-repositories.sh` to support this workflow, in case there are other users who prefer it to a pull.