### PR TITLE
Add basic infrastructure for building docs.

### DIFF
--- a/dockerfiles/rapids.Dockerfile
+++ b/dockerfiles/rapids.Dockerfile
@@ -20,11 +20,9 @@ RUN echo 'Acquire::HTTP::Proxy "http://172.17.0.1:3142";' >> /etc/apt/apt.conf.d
  && add-apt-repository -y ppa:git-core/ppa \
  && apt update -y \
  && apt install -y \
-    git sudo \
-    curl wget \
+    jq ed git vim nano sudo curl wget entr \
     # Needed to build ccache from master
     unzip automake autoconf libb2-dev libzstd-dev \
-    jq ed vim nano \
     # Need tzdata for the pyarrow<->ORC tests
     tzdata \
     apt-utils \

--- a/dockerfiles/rapids.Dockerfile
+++ b/dockerfiles/rapids.Dockerfile
@@ -30,6 +30,7 @@ RUN echo 'Acquire::HTTP::Proxy "http://172.17.0.1:3142";' >> /etc/apt/apt.conf.d
     gcc-7 g++-7 \
     gcc-8 g++-8 \
     ninja-build \
+    doxygen graphviz \
     libboost-all-dev \
     python3 python3-pip \
     apt-transport-https \

--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -556,6 +556,14 @@ clean-cuspatial-python() {
 
 export -f clean-cuspatial-python;
 
+docs-cudf-cpp() {
+    update-environment-variables $@ >/dev/null;
+    print-heading "Generating docs for libcudf";
+    docs-cpp "$CUDF_HOME/cpp/doxygen";
+}
+
+export -f docs-cudf-cpp;
+
 lint-rmm-cpp() {
     print-heading "Linting librmm" && lint-cpp "$RMM_HOME";
 }
@@ -846,6 +854,19 @@ build-python() {
 }
 
 export -f build-python;
+
+docs-cpp() {
+    (
+        cd "$1";
+        doxygen
+        if [[ -n $2 ]]; then
+            cd html
+            python -m http.server --bind localhost $2
+        fi
+    )
+}
+
+export -f docs-cpp;
 
 lint-cpp() {
     (

--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -77,7 +77,7 @@
 # Commands to build documentation for each project separately:
 #
 # docs-rmm-cpp          - (✝) Build the librmm C++ library documentation
-# docs-cudf-cpp          - (✝) Build the libcudf C++ library documentation
+# docs-cudf-cpp         - (✝) Build the libcudf C++ library documentation
 # docs-cuml-cpp         - (✝) Build the libcuml C++ library documentation
 # docs-cugraph-cpp      - (✝) Build the libcugraph C++ library documentation
 # docs-cuspatial-cpp    - (✝) Build the libcuspatial C++ library documentation

--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -3,21 +3,21 @@
 # set -Eeo pipefail
 
 ############
-# 
+#
 # This file defines and exports a set of helpful bash functions.
-# 
+#
 # Before executing, each of these functions will read the .env file in your
 # rapids-compose repo. It is safe to edit the .env file while the container
 # is running and re-execute any of these commands. The edited value will be
 # reflected in the command execution.
-# 
+#
 # Note: The (✝) character at the beginning of a command's description denotes
 #       the command can be run from any directory.
-# 
+#
 # Note: All commands accept the following optional arguments. These arguments
 #       will take precedence over .env configurations. If an argument is
 #       omitted, the corresponding .env configuration will be used.
-# 
+#
 # --rmm         Build librmm and rmm
 # --cudf        Build libcudf and cudf (implies --rmm)
 # --cuml        Build libcuml and cuml (implies --cudf)
@@ -27,7 +27,7 @@
 # -t, --tests   Build C++ unit tests
 # -d, --debug   Build C++ with CMAKE_BUILD_TYPE=Debug
 # -r, --release Build C++ with CMAKE_BUILD_TYPE=Release
-# 
+#
 # Examples:
 #   build-rmm-cpp --release        Build the librmm C++ library in release mode
 #   build-rmm-cpp --debug --tests  Build the librmm C++ library and tests in debug mode
@@ -45,63 +45,77 @@
 #
 ###
 # Commands to build each project separately:
-# 
+#
 # build-rmm-cpp          - (✝) Build the librmm C++ library
 # build-cudf-cpp         - (✝) Build the libcudf C++ library
 # build-cuml-cpp         - (✝) Build the libcuml C++ library
 # build-cugraph-cpp      - (✝) Build the libcugraph C++ library
 # build-cuspatial-cpp    - (✝) Build the libcuspatial C++ library
-# 
+#
 # build-rmm-python       - (✝) Build the rmm Cython bindings
 # build-cudf-python      - (✝) Build the cudf Cython bindings
 # build-cuml-python      - (✝) Build the cuml Cython bindings
 # build-cugraph-python   - (✝) Build the cugraph Cython bindings
 # build-cuspatial-python - (✝) Build the cuspatial Cython bindings
-# 
+#
 ###
 # Commands to clean each project separately:
-# 
+#
 # clean-rmm-cpp          - (✝) Clean the librmm C++ build artifacts for the current git branch
 # clean-cudf-cpp         - (✝) Clean the libcudf C++ build artifacts for the current git branch
 # clean-cuml-cpp         - (✝) Clean the libcuml C++ build artifacts for the current git branch
 # clean-cugraph-cpp      - (✝) Clean the libcugraph C++ build artifacts for the current git branch
 # clean-cuspatial-cpp    - (✝) Clean the libcuspatial C++ build artifacts for the current git branch
-# 
+#
 # clean-rmm-python       - (✝) Clean the rmm Cython build assets
 # clean-cudf-python      - (✝) Clean the cudf Cython build assets
 # clean-cuml-python      - (✝) Clean the cuml Cython build assets
 # clean-cugraph-python   - (✝) Clean the cugraph Cython build assets
 # clean-cuspatial-python - (✝) Clean the cuspatial Cython build assets
-# 
+#
 ###
+# Commands to build documentation for each project separately:
+#
+# docs-rmm-cpp          - (✝) Build the librmm C++ library documentation
+# docs-cudf-cpp          - (✝) Build the libcudf C++ library documentation
+# docs-cuml-cpp         - (✝) Build the libcuml C++ library documentation
+# docs-cugraph-cpp      - (✝) Build the libcugraph C++ library documentation
+# docs-cuspatial-cpp    - (✝) Build the libcuspatial C++ library documentation
+#
+# docs-rmm-python       - (✝) Build the rmm Python library documentation
+# docs-cudf-python      - (✝) Build the cudf library documentation
+# docs-cuml-python      - (✝) Build the cuml library documentation
+# docs-cugraph-python   - (✝) Build the cugraph library documentation
+# docs-cuspatial-python - (✝) Build the cuspatial library documentation
+####
 # Commands to lint each C++ project separately:
-# 
+#
 # lint-rmm-cpp        - (✝) Lint/fix the librmm C++/CUDA source files with clang-format
 # lint-cudf-cpp       - (✝) Lint/fix the libcudf C++/CUDA source files with clang-format
 # lint-cuml-cpp       - (✝) Lint/fix the libcuml C++/CUDA source files with clang-format
 # lint-cugraph-cpp    - (✝) Lint/fix the libcugraph C++/CUDA source files with clang-format
 # lint-cuspatial-cpp  - (✝) Lint/fix the libcuspatial C++/CUDA source files with clang-format
-# 
+#
 ###
 # Commands to lint each Python project separately:
-# 
+#
 # lint-rmm-python        - (✝) Lint/fix the rmm Cython and Python source files
 # lint-cudf-python       - (✝) Lint/fix the cudf Cython and Python source files
 # lint-cuml-python       - (✝) Lint/fix the cuml Cython and Python source files
 # lint-cugraph-python    - (✝) Lint/fix the cugraph Cython and Python source files
 # lint-cuspatial-python  - (✝) Lint/fix the cuspatial Cython and Python source files
-# 
+#
 ###
-# Commands to run each project's cpp tests:
+# Commands to run each project's C++ tests:
 #
 # Note: These commands automatically build (if necessary) before testing.
 # Note: Flags are passed to ctest. To see a list of all avaialble flags, run ctest --help
 #
-# test-rmm-cpp        - (✝) Run rmm cpp tests
-# test-cudf-cpp       - (✝) Run cudf cpp tests
-# test-cuml-cpp       - (✝) Run cuml cpp tests
-# test-cugraph-cpp    - (✝) Run cugraph cpp tests
-# test-cuspatial-cpp  - (✝) Run cuspatial cpp tests
+# test-rmm-cpp        - (✝) Run librmm C++ tests
+# test-cudf-cpp       - (✝) Run libcudf C++ tests
+# test-cuml-cpp       - (✝) Run libcuml C++ tests
+# test-cugraph-cpp    - (✝) Run libcugraph C++ tests
+# test-cuspatial-cpp  - (✝) Run libcuspatial C++ tests
 #
 # Usage:
 # test-rmm-cpp TEST_NAME OTHER_TEST_NAME - Build `TEST_NAME` and `OTHER_TEST_NAME`, then execute.
@@ -109,28 +123,28 @@
 #
 ###
 # Commands to run each project's pytests:
-# 
+#
 # Note: These commands automatically change into the correct directory before executing `pytest`.
 # Note: Pass --debug to use with the VSCode debugger `ptvsd`. All other arguments are forwarded to pytest.
 # Note: Arguments that end in '.py' are assumed to be pytest files used to reduce the number of tests
 #       collected on startup by pytest. These arguments will be expanded out to their full paths relative
 #       to the directory where pytests is run.
-# 
+#
 # test-rmm-python        - (✝) Run rmm pytests
 # test-cudf-python       - (✝) Run cudf pytests
 # test-cuml-python       - (✝) Run cuml pytests
 # test-cugraph-python    - (✝) Run cugraph pytests
 # test-cuspatial-python  - (✝) Run cuspatial pytests
-# 
+#
 # Usage:
 # test-cudf-python -n <num_cores>                               - Run all pytests in parallel with `pytest-xdist`
 # test-cudf-python -v -x -k 'a_test_function_name'              - Run all tests named 'a_test_function_name', be verbose, and exit on first fail
 # test-cudf-python -v -x -k 'a_test_function_name' --debug      - Run all tests named 'a_test_function_name', and start ptvsd for VSCode debugging
 # test-cudf-python -v -x -k 'test_a or test_b' foo/test_file.py - Run all tests named 'test_a' or 'test_b' in file paths matching foo/test_file.py
-# 
+#
 ###
 # Misc
-# 
+#
 # cpp-build-type               - (✝) Function to print the C++ CMAKE_BUILD_TYPE
 # cpp-build-dir                - (✝) Function to print the C++ build path relative to a project's C++ source directory
 # make-symlink                 - (✝) Function to safely make non-dereferenced symlinks


### PR DESCRIPTION
@trxcllnt I started a feature branch for building documentation. I wanted your input on a few items before progressing:

- Should the documentation builds also automatically serve the docs with `python -m http.server` on a port of `localhost`? My preference would be yes.
- If so, should the user specify that port in the `.env` configuration? It could just be a single port number shared by all packages when building/serving docs, to ensure easy port forwarding through the Docker container and any remote SSH clients. Ideally it would be unique per-user, like the GPU id, to avoid conflicts with shared remote workstations.
- How should the port option be overridden? (I haven't spent long enough to fully understand how configuration options are handled yet.)

Feel free to make changes directly on this branch if you have thoughts about the auto-serving/port selection logic. Once there is a baseline for libcudf C++ docs, I can make it work with other packages and Python docs.