### PR TITLE
support cmake find_package(CUDAToolkit)

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -935,7 +935,8 @@ configure-cpp() {
             -D CMAKE_SYSTEM_PREFIX_PATH=${CONDA_HOME}/envs/rapids
             -D ARROW_INCLUDE=${CONDA_HOME}/envs/rapids/include
             -D ARROW_LIBRARY=${CONDA_HOME}/envs/rapids/lib/libarrow.so
-            -D ARROW_CUDA_LIBRARY=${CONDA_HOME}/envs/rapids/lib/libarrow_cuda.so";
+            -D ARROW_CUDA_LIBRARY=${CONDA_HOME}/envs/rapids/lib/libarrow_cuda.so
+            -D CUDAToolkit_ROOT=${CUDA_HOME}";
 
         CMAKE_GENERATOR="Ninja";
         CMAKE_C_FLAGS="-fdiagnostics-color=always"


### PR DESCRIPTION
Fixes the following error.
```
Make Error at /home/cwharris/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:164 (message):
  Could NOT find CUDAToolkit (missing: CUDAToolkit_INCLUDE_DIR) (found
  version "10.2.89")
```