### PR TITLE
Use the docker bridge network

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # RAPIDS docker-compose environment for Ubuntu 16.04/18.04
 
 ## Quick links
+
 * [Synopsis](#synopsis)
 * [Installation](#installation)
   * [Updating](#updating)
@@ -16,48 +17,47 @@ development and notebooks starting from a clean install of Ubuntu 16.04
 or 18.04. It automates the following steps:
 
 1. Installation of dependencies:
-   - [Clangd](https://clang.llvm.org/extra/clangd/) - a language server used to
+   * [Clangd](https://clang.llvm.org/extra/clangd/) - a language server used to
      add smart features to an IDE, e.g. VSCode.
-   - [Visual Studio Code](https://code.visualstudio.com/) - an IDE.
-   - [Docker](https://www.docker.com/resources/what-container) - A container
+   * [Visual Studio Code](https://code.visualstudio.com/) - an IDE.
+   * [Docker](https://www.docker.com/resources/what-container) - A container
      technology for packaging up code with all its dependencies.
-   - [`docker-compose`](https://docs.docker.com/compose/) - A tool for building,
+   * [`docker-compose`](https://docs.docker.com/compose/) - A tool for building,
      configuring, and running groups of docker containers
-   - [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) - For
+   * [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) - For
      building GPU-accelerated docker containers.
 2. Creation of a `docker-compose` environment:
-   - Contains suitable settings of compiler and Python versions and other build
+   * Contains suitable settings of compiler and Python versions and other build
      parameters.
 3. Creation of a VSCode workspace:
-   - Sets up syntax highlighting, intellisense for C++, CUDA and Python
-   - Set up some Git conveniences.
+   * Sets up syntax highlighting, intellisense for C++, CUDA and Python
+   * Set up some Git conveniences.
 4. Forking and cloning of the RAPIDS repositories:
-   - [RAPIDS Memory Manager](https://github.com/rapidsai/rmm)
-   - [cuDF](https://github.com/rapidsai/cudf)
-   - [cuGraph](https://github.com/rapidsai/cugraph)
-   - [RAPIDS Sample Notebooks](https://github.com/rapidsai/notebooks)
-   - [RAPIDS Community Notebooks](https://github.com/rapidsai/notebooks-contrib)
+   * [RAPIDS Memory Manager](https://github.com/rapidsai/rmm)
+   * [cuDF](https://github.com/rapidsai/cudf)
+   * [cuGraph](https://github.com/rapidsai/cugraph)
+   * [RAPIDS Sample Notebooks](https://github.com/rapidsai/notebooks)
+   * [RAPIDS Community Notebooks](https://github.com/rapidsai/notebooks-contrib)
 5. Creation of containers for development work:
-   - `dind`: The Docker-in-Docker container. This container is built first to
+   * `dind`: The Docker-in-Docker container. This container is built first to
      provide a clean environment for running `docker-compose` in to build the
      other containers. This allows us to mount your local filesystem as docker
      volumes while selectively ignoring folders that bloat the docker build
      cache and slow down container builds.
-   - `rapids`: Contains builds of all the RAPIDS repositories listed above and
+   * `rapids`: Contains builds of all the RAPIDS repositories listed above and
      tooling to support development with Visual Studio Code.
-   - `notebooks`: Serves Jupyter notebooks using the RAPIDS libraries built by
+   * `notebooks`: Serves Jupyter notebooks using the RAPIDS libraries built by
      the `rapids` container. This allows you to easily test out new features or
      fixes to C++ or Python in any of our example demo notebooks.
-
 
 ## Installation
 
 Starting with the assumption that this repository has not yet been cloned, and
 no other dependencies are installed, these steps:
 
-- Install all dependencies,
-- Fork and clone the RAPIDS repositories,
-- Set up the VSCode environment and Intellisense.
+* Install all dependencies,
+* Fork and clone the RAPIDS repositories,
+* Set up the VSCode environment and Intellisense.
 
 During execution, you will be asked if you would like to install various
 dependencies - it is generally a sensible and safe to answer "yes" to these
@@ -104,7 +104,6 @@ git pull origin master
 make init
 ```
 
-
 ## Usage
 
 ### Building the containers
@@ -129,7 +128,6 @@ or modifing the container `Dockerfiles`), or if you want to take a coffee break
 and come back to a fully re-built set of RAPIDS projects, it's always safe to
 `docker rm -f` any existing rapids containers and re-run `make` from top.
 
-
 ### Launching the Notebook container
 
 To launch the notebook container (needed each time the system is started):
@@ -138,6 +136,38 @@ To launch the notebook container (needed each time the system is started):
 make notebooks.run
 ```
 
+If launching the notebooks container on a remote SSH host, you'll need to tunnel a port on your local machine to the remote container.
+
+When you run the notebooks container, you should see a message like this:
+
+```shell
+[I 17:42:35.595 LabApp] Jupyter Notebook 6.1.4 is running at:
+[I 17:42:35.595 LabApp] http://172.19.0.4:8888/
+```
+
+Take the IP address from the previous message, and run this in a terminal on your local machine:
+
+```shell
+# -f -- run SSH in the background
+# -N -- don't execute a command on the remote host
+# -L -- forward `local_host:port` to `remote_host:port`
+ssh -f -N -L 127.0.0.1:8888:172.19.0.4:8888 <user_name>@<remote_host>
+```
+
+Then open up `127.0.0.1:8888` on your machine, and you should be connected to the remote JupyterLab server.
+
+When you're done, you can find the PID of the backgrounded SSH process like this:
+
+```shell
+$ pgrep -u $(id -u) ssh --list-full
+190374 ssh -f -N -L 127.0.0.1:8888:172.19.0.4:8888 <user_name>@<remote_host>
+```
+
+Then you can kill it like this:
+
+```shell
+kill -9 190374
+```
 
 ### Running tests
 
@@ -150,7 +180,6 @@ make rapids.cudf.pytest args="-k 'test_string_index'"
 
 To run pytests in parallel with pytest-xdist, pass `args="-n auto"`.
 
-
 ### Debugging tests
 
 To debug tests running in the container, use the `rapids.cudf.pytest.debug`:
@@ -161,7 +190,6 @@ make rapids.cudf.pytest.debug args="-k 'test_reindex_dataframe'"
 
 This launches pytest with `ptvsd` for debugging in VSCode.
 
-
 ### Working interactively in the RAPIDS container
 
 To run the rapids container and launch a tty to explore it interactively, run:
@@ -169,7 +197,6 @@ To run the rapids container and launch a tty to explore it interactively, run:
 ```shell
 make rapids.run args="bash"
 ```
-
 
 ## Miscellaneous Troubleshooting
 
@@ -179,33 +206,32 @@ make rapids.run args="bash"
 conflicts. What do I do?"
 
 `rapids-compose` builds a combined conda environment from the environments of all the RAPIDS
-repos (cuDF, cuML, cuGraph, RMM, etc.). So if one of those repos on your system is out of sync, 
+repos (cuDF, cuML, cuGraph, RMM, etc.). So if one of those repos on your system is out of sync,
 there can be conflicts. To solve this:
 
- * ensure you have all repos pulled to the same branch. If you are working on a feature branch,
-   you may need to merge the latest from the base branch into your feature branch.
- * `compose/scripts/git-checkout-same-branch.sh` is a script that automates checking out all of your
-   repos to the same branch. It examines the repos and prompts with a choice of common branches.
- * If you are using a CUDA toolkit release candidate or prerelease (e.g. CUDA 11.0 RC), there may
-   not be conda packages for this available yet. In this case, you can still build RAPIDS libraries 
-   (e.g. libcudf.so) from source, but you may not be able to build and use the Python 
-   bindings/libraries. In this situation, in the `compose/.env` file, you need to set `CUDA_VERSION`
-   to the version of the CUDA toolkit you want to use, but set `CONDA_CUDA_TOOLKIT_VERSION` to the 
-   latest earlier version for which conda packages exist. So in the case of working with CUDA 11.0 
-   RC, set
+* ensure you have all repos pulled to the same branch. If you are working on a feature branch,
+  you may need to merge the latest from the base branch into your feature branch.
+* `compose/scripts/git-checkout-same-branch.sh` is a script that automates checking out all of your
+  repos to the same branch. It examines the repos and prompts with a choice of common branches.
+* If you are using a CUDA toolkit release candidate or prerelease (e.g. CUDA 11.0 RC), there may
+  not be conda packages for this available yet. In this case, you can still build RAPIDS libraries
+  (e.g. libcudf.so) from source, but you may not be able to build and use the Python
+  bindings/libraries. In this situation, in the `compose/.env` file, you need to set `CUDA_VERSION`
+  to the version of the CUDA toolkit you want to use, but set `CONDA_CUDA_TOOLKIT_VERSION` to the
+  latest earlier version for which conda packages exist. So in the case of working with CUDA 11.0
+  RC, set:
 
-   ```
-   CUDA_VERSION=11.0
-   CONDA_CUDA_TOOLKIT_VERSION=10.2
-   ```
-  
+  ```shell
+  CUDA_VERSION=11.0
+  CONDA_CUDA_TOOLKIT_VERSION=10.2
+  ```
 
 ### DNS Resolution Issues
 
 When creating the Docker-in-Docker container, downloading of the Alpine package
 release key fails with the following error:
 
-```
+```shell
 + wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 wget: bad address 'alpine-pkgs.sgerrand.com'
 ```
@@ -218,7 +244,8 @@ If this occurs, a possible resolution is to restart the machine and attempt
 
 Alternatively, you can use the Cisco-compatible OpenConnect VPN client, which
 seems to have better integration with `systemd`:
-```
+
+```shell
 sudo apt install network-manager-openconnect-gnome
 ```
 
@@ -227,7 +254,7 @@ sudo apt install network-manager-openconnect-gnome
 When building the RAPIDS container, an error running `groupadd` is encountered
 just after the build of `ccache`:
 
-```
+```shell
 ...
   INSTALL  ccache
   INSTALL  ccache.1
@@ -238,8 +265,8 @@ groupadd: GID '0' already exists
 This occurs if you are running `make init` as root. You should run it under your
 normal user account.
 
-
 ## Wishlist
 
 ## Acknowledgements
+
 Inspired by container development patterns from @MillerHooks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.6"
 
 x-service-settings: &service_settings
   env_file: .env
-  network_mode: host
   build: &build_settings
     context: ..
     args:
@@ -109,3 +108,7 @@ services:
 
 volumes:
   apt-cache:
+
+networks:
+  default:
+    driver: bridge

--- a/dockerfiles/notebooks.Dockerfile
+++ b/dockerfiles/notebooks.Dockerfile
@@ -14,4 +14,4 @@ RUN apt update -y --fix-missing && apt upgrade -y \
 exec \"$COMPOSE_HOME/etc/notebooks/start.sh\" \"\$@\"\n\
 '" > /entrypoint.sh && chown ${_UID}:${_GID} /entrypoint.sh && chmod +x /entrypoint.sh
 
-CMD ["jupyter-lab", "--ip=0.0.0.0", "--no-browser", "--NotebookApp.token=''"]
+CMD ["jupyter-lab", "--ip=$(cat /etc/hosts | tail -n1 | cut -d$'\t' -f1)", "--no-browser", "--NotebookApp.token=''"]

--- a/dockerfiles/notebooks.Dockerfile
+++ b/dockerfiles/notebooks.Dockerfile
@@ -11,7 +11,7 @@ RUN apt update -y --fix-missing && apt upgrade -y \
  && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* \
  \
  && bash -c "echo -e '#!/bin/bash -e\n\
-exec \"$COMPOSE_HOME/etc/notebooks/start.sh\" \"\$@\"\n\
+exec \"\$COMPOSE_HOME/etc/notebooks/start.sh\" \"\$@\"\n\
 '" > /entrypoint.sh && chown ${_UID}:${_GID} /entrypoint.sh && chmod +x /entrypoint.sh
 
 CMD ["jupyter-lab", "--ip=$(cat /etc/hosts | tail -n1 | cut -d$'\t' -f1)", "--no-browser", "--NotebookApp.token=''"]

--- a/dockerfiles/rapids.Dockerfile
+++ b/dockerfiles/rapids.Dockerfile
@@ -143,7 +143,7 @@ RUN mkdir -p /var/log "$RAPIDS_HOME" "$CONDA_HOME" \
  && chown -R ${_UID}:${_GID} "$RAPIDS_HOME" "$CONDA_HOME" \
  && chmod -R 0755 /var/log "$RAPIDS_HOME" "$CONDA_HOME" \
  && bash -c "echo -e '#!/bin/bash -e\n\
-exec \"$COMPOSE_HOME/etc/rapids/start.sh\" \"\$@\"\n\
+exec \"\$COMPOSE_HOME/etc/rapids/start.sh\" \"\$@\"\n\
 '" > /entrypoint.sh \
  && touch "$RAPIDS_HOME/.bashrc" && touch "$RAPIDS_HOME/.bash_history" \
  && chown ${_UID}:${_GID} /entrypoint.sh "$RAPIDS_HOME/.bashrc" "$RAPIDS_HOME/.bash_history" \

--- a/scripts/06-setup-python-intellisense.sh
+++ b/scripts/06-setup-python-intellisense.sh
@@ -48,12 +48,23 @@ for PYDIR in $PYTHON_DIRS; do
             "type": "python",
             "request": "attach",
             "port": 5678,
-            "host": "localhost",
+            "host": "\${input:rapids_container_ip}",
             "pathMappings": [{
                 "localRoot": "\${workspaceFolder}",
                 "remoteRoot": "\${workspaceFolder}"
             }]
         }
+    ],
+    "inputs": [
+        {
+            "type": "command",
+            "id": "rapids_container_ip",
+            "command": "shellCommand.execute",
+            "args": {
+                "useFirstResult": true,
+                "command": "docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \$(docker ps | grep rapidsai/\$(whoami)/rapids | cut -d\" \" -f1)"
+            }
+        },
     ]
 }
 EOF


### PR DESCRIPTION
Switches the docker network mode to use the default bridge network instead of host so we behave better on multi-tenant systems.