### PR TITLE
Fix build-cudf-java to handle cpp build dir correctly

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -327,6 +327,7 @@ export -f build-cudf-cpp;
 
 build-cudf-java() {
     CUDF_JNI_HOME="$CUDF_HOME/java/src/main/native";
+    CUDF_CPP_BUILD_DIR="$(find-cpp-build-home $1)"
     D_CMAKE_ARGS=$(update-environment-variables $@);
     D_CMAKE_ARGS=$(echo $(echo "$D_CMAKE_ARGS"))
     (
@@ -338,6 +339,7 @@ build-cudf-java() {
             ${D_CMAKE_ARGS} \
             -Dmaven.test.skip=true \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCUDF_CPP_BUILD_DIR="$CUDF_HOME/$CUDF_CPP_BUILD_DIR" \
             -Dnative.build.path="$CUDF_JNI_ROOT" 
         export CONDA_PREFIX="$CONDA_PREFIX_"; unset CONDA_PREFIX_;
         fix-nvcc-clangd-compile-commands "$CUDF_JNI_HOME" "$CUDF_JNI_ROOT_ABS"


### PR DESCRIPTION
Makes `build-cudf-java` work when the CUDF CPP build directory is not the default.  Depends on rapidsai/cudf#6732 (already merged)