### PR TITLE
Fix rapids.Dockerfile

### DIFF
--- a/dockerfiles/rapids.Dockerfile
+++ b/dockerfiles/rapids.Dockerfile
@@ -179,9 +179,9 @@ ENV FRESH_CONDA_ENV=$FRESH_CONDA_ENV
 
 WORKDIR $RAPIDS_HOME
 
-COPY compose/etc/rapids/colornvcc /usr/bin/nvcc
-COPY compose/etc/rapids/.bashrc "$RAPIDS_HOME/.bashrc"
-COPY compose/etc/settings/.colornvccrc "$RAPIDS_HOME/.colornvccrc"
+COPY rapids-compose/etc/rapids/colornvcc /usr/bin/nvcc
+COPY rapids-compose/etc/rapids/.bashrc "$RAPIDS_HOME/.bashrc"
+COPY rapids-compose/etc/settings/.colornvccrc "$RAPIDS_HOME/.colornvccrc"
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
 


### PR DESCRIPTION
Came across a problem when setting up `rapids-compose` from scratch. 