### PR TITLE
update pull script to not fetch tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ DEFAULT_PYTHON_VERSION := 3.7
 DEFAULT_LINUX_VERSION := ubuntu18.04
 DEFAULT_RAPIDS_NAMESPACE := $(shell echo $$USER)
 DEFAULT_RAPIDS_VERSION := $(shell RES="" \
- && [ -z "$$RES" ] && RES=$$(cd ../cudf 2>/dev/null && git describe --abbrev=0 --tags) || true \
  && [ -z "$$RES" ] && [ -n `which curl` ] && [ -n `which jq` ] && RES=$$(curl -s https://api.github.com/repos/rapidsai/cudf/tags | jq -e -r ".[].name" 2>/dev/null | head -n1) || true \
  && echo $${RES:-"latest"})
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       <<: *build_settings
       dockerfile: "${COMPOSE_HOME:-$PWD/compose}/dockerfiles/rapids.Dockerfile"
     volumes:
+      - &js "${RAPIDS_HOME:-$PWD}/rapids-js:${RAPIDS_HOME:-$PWD}/rapids-js"
       - &rmm "${RAPIDS_HOME:-$PWD}/rmm:${RAPIDS_HOME:-$PWD}/rmm"
       - &cudf "${RAPIDS_HOME:-$PWD}/cudf:${RAPIDS_HOME:-$PWD}/cudf"
       - &cuml "${RAPIDS_HOME:-$PWD}/cuml:${RAPIDS_HOME:-$PWD}/cuml"

--- a/scripts/04-clone-rapids-repositories.sh
+++ b/scripts/04-clone-rapids-repositories.sh
@@ -59,7 +59,7 @@ install_github_cli() {
 
 clone_repo() {
     REPO="$1"
-    git clone -c checkout.defaultRemote=upstream -j $(nproc) \
+    git clone --no-tags -c checkout.defaultRemote=upstream -j $(nproc) \
         --recurse-submodules https://github.com/rapidsai/$REPO.git
 }
 

--- a/scripts/fetch-rapids-repositories.sh
+++ b/scripts/fetch-rapids-repositories.sh
@@ -11,6 +11,6 @@ ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks-contrib}"
 
 for REPO in $ALL_REPOS; do
     cd "$BASE_DIR/$REPO";
-    git fetch upstream && git fetch origin;
+    git fetch --no-tags upstream && git fetch --no-tags origin;
     cd - >/dev/null 2>&1;
 done

--- a/scripts/git-checkout-same-branch.sh
+++ b/scripts/git-checkout-same-branch.sh
@@ -15,7 +15,7 @@ echo "Determining available branches."
 for REPO in $CODE_REPOS; do
     echo "$REPO ..."
     cd "$BASE_DIR/$REPO";
-    git fetch upstream;
+    git fetch --no-tags upstream;
     REMOTE_BRANCHES="";
     for x in $(git branch -r | grep upstream); do
         REMOTE_BRANCHES="${REMOTE_BRANCHES:+$REMOTE_BRANCHES\n}${x#upstream/}";

--- a/scripts/pull-rapids-repositories.sh
+++ b/scripts/pull-rapids-repositories.sh
@@ -11,7 +11,7 @@ ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks-contrib}"
 
 for REPO in $ALL_REPOS; do
     cd "$BASE_DIR/$REPO";
-    git fetch upstream && git fetch origin;
+    git fetch upstream --no-tags && git fetch origin;
     BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)";
     while [ -z "$(git branch -r | grep upstream/$BRANCH_NAME)" ]; do
         UPSTREAM_INFO="$(git remote -v show | grep upstream | head -n1)";

--- a/scripts/pull-rapids-repositories.sh
+++ b/scripts/pull-rapids-repositories.sh
@@ -11,7 +11,7 @@ ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks-contrib}"
 
 for REPO in $ALL_REPOS; do
     cd "$BASE_DIR/$REPO";
-    git fetch upstream --no-tags && git fetch origin;
+    git fetch --no-tags upstream && git fetch --no-tags origin;
     BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)";
     while [ -z "$(git branch -r | grep upstream/$BRANCH_NAME)" ]; do
         UPSTREAM_INFO="$(git remote -v show | grep upstream | head -n1)";
@@ -24,7 +24,7 @@ ${UPSTREAM_INFO}
 Please enter a branch name to pull (or leave empty to skip): " BRANCH_NAME </dev/tty
     done
     if [ -n "$BRANCH_NAME" ]; then
-        git pull upstream "$BRANCH_NAME";
+        git pull --no-tags upstream "$BRANCH_NAME";
         git submodule update --init --recursive;
     else
         echo -e "No alternate branch name supplied, skipping\n";


### PR DESCRIPTION
Recently RAPIDS repos have had tags added (`*-latest`) which are force-pushed, causing fetches to become "unsafe". This PR updates the repositories pull script to _not_ fetch tags from upstream, which should avoid the force-pushed tags issue.

If we still want tags, we could alternatively update to:
```
git fetch upstream --tags -f && git fetch upstream --no-tags && git fetch origin;
```