### PR TITLE
Set `CONDA_CUDA_TOOLKIT_VERSION` in init

### DIFF
--- a/scripts/02-create-compose-env.sh
+++ b/scripts/02-create-compose-env.sh
@@ -77,11 +77,7 @@ NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-$(select_version "Select which 
 BUILD_TESTS=${BUILD_TESTS:-$(select_version "Select whether to configure to build RAPIDS tests (ON/OFF)" "ON")}
 BUILD_BENCHMARKS=${BUILD_BENCHMARKS:-$(select_version "Select whether to configure to build RAPIDS benchmarks (ON/OFF)" "ON")}
 
-if [[ "$CUDA_VERSION" != "11.2.0" ]]; then
-  CONDA_CUDA_TOOLKIT_VERSION="$CUDA_VERSION"
-else
-  CONDA_CUDA_TOOLKIT_VERSION="11.2"
-fi
+CONDA_CUDA_TOOLKIT_VERSION=$(echo $CUDA_VERSION | cut -d'.' -f1,2)
 
 USE_CCACHE=${USE_CCACHE:-$(choose_bool_option "Use ccache for C++ builds? (y/n)" "YES")}
 

--- a/scripts/02-create-compose-env.sh
+++ b/scripts/02-create-compose-env.sh
@@ -77,6 +77,12 @@ NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-$(select_version "Select which 
 BUILD_TESTS=${BUILD_TESTS:-$(select_version "Select whether to configure to build RAPIDS tests (ON/OFF)" "ON")}
 BUILD_BENCHMARKS=${BUILD_BENCHMARKS:-$(select_version "Select whether to configure to build RAPIDS benchmarks (ON/OFF)" "ON")}
 
+if [[ "$CUDA_VERSION" != "11.2.0" ]]; then
+  CONDA_CUDA_TOOLKIT_VERSION="$CUDA_VERSION"
+else
+  CONDA_CUDA_TOOLKIT_VERSION="11.2"
+fi
+
 USE_CCACHE=${USE_CCACHE:-$(choose_bool_option "Use ccache for C++ builds? (y/n)" "YES")}
 
 if [[ "$USE_CCACHE" == "YES" ]]; then
@@ -113,6 +119,7 @@ COMPOSE_HOME=$COMPOSE_HOME
 # Build arguments
 GCC_VERSION=$GCC_VERSION
 CUDA_VERSION=$CUDA_VERSION
+CONDA_CUDA_TOOLKIT_VERSION=$CONDA_CUDA_TOOLKIT_VERSION
 PYTHON_VERSION=$PYTHON_VERSION
 LINUX_VERSION=ubuntu18.04
 


### PR DESCRIPTION
When building with the CUDA 11.2.0 toolkit, solving the conda environment can fail with:

```
Encountered problems while solving:
  - package libcumlprims-21.08.00a210602-cuda11.2_g8d4e6b0_2 requires cudatoolkit >=11.2.72,<11.3.0a0, but none of the providers can be installed
```

This is because `CONDA_CUDA_TOOLKIT_VERSION` needs to be set to 11.2 (the version format being `major.minor`).

To avoid this, we set `CONDA_CUDA_TOOLKIT_VERSION` appropriately when running `make init`.