### PR TITLE
Fix test-cudf-python test directory.

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -916,7 +916,7 @@ test-rmm-python() {
 export -f test-rmm-python;
 
 test-cudf-python() {
-    test-python "$CUDF_HOME/python/cudf" $@;
+    test-python "$CUDF_HOME/python/cudf/cudf/tests" $@;
 }
 
 export -f test-cudf-python;


### PR DESCRIPTION
This points `test-cudf-python` to the more specific tests directory so that it doesn't get confused by the `python/benchmarks` directory.

Error output:
```
________________________ ERROR collecting cudf/benchmarks/bench_cudf_io.py ________________________
ImportError while importing test module '~/rapids/cudf/python/cudf/cudf/benchmarks/bench_cudf_io.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../compose/etc/conda/cuda_11.2/envs/rapids/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
cudf/benchmarks/bench_cudf_io.py:7: in <module>
    from conftest import option
E   ImportError: cannot import name 'option' from 'conftest' (~/rapids/cudf/python/cudf/cudf/tests/conftest.py)
```