### PR TITLE
Add libnuma to rapids image

### DIFF
--- a/dockerfiles/rapids.Dockerfile
+++ b/dockerfiles/rapids.Dockerfile
@@ -66,6 +66,8 @@ fi' \
     libxi6 \
     libxml2 \
     libxrender1 \
+    libnuma1 \
+    libnuma-dev \
  && bash -c '\
 if [[ "$USE_FISH_SHELL" == "YES" ]]; then \
     apt install --no-install-recommends -y fish; \


### PR DESCRIPTION
Libnuma needs to be installed for UCX to load it. See also:

https://github.com/rapidsai/gpuci-build-environment/pull/209