### PR TITLE
Print the repo name for git operations

### DIFF
--- a/scripts/fetch-rapids-repositories.sh
+++ b/scripts/fetch-rapids-repositories.sh
@@ -10,6 +10,7 @@ CODE_REPOS="${CODE_REPOS:-rmm raft cudf cuml cugraph cuspatial}"
 ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks-contrib}"
 
 for REPO in $ALL_REPOS; do
+    echo "Fetching $REPO..."
     cd "$BASE_DIR/$REPO";
     git fetch --no-tags upstream && git fetch --no-tags origin;
     cd - >/dev/null 2>&1;

--- a/scripts/merge-rapids-repositories.sh
+++ b/scripts/merge-rapids-repositories.sh
@@ -10,6 +10,7 @@ CODE_REPOS="${CODE_REPOS:-rmm raft cudf cuml cugraph cuspatial}"
 ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks-contrib}"
 
 for REPO in $ALL_REPOS; do
+    echo "Merging $REPO..."
     cd "$BASE_DIR/$REPO";
     BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)";
     while [ -z "$(git branch -r | grep upstream/$BRANCH_NAME)" ]; do

--- a/scripts/pull-rapids-repositories.sh
+++ b/scripts/pull-rapids-repositories.sh
@@ -10,6 +10,7 @@ CODE_REPOS="${CODE_REPOS:-rmm raft cudf cuml cugraph cuspatial}"
 ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks-contrib}"
 
 for REPO in $ALL_REPOS; do
+    echo "Pulling $REPO..."
     cd "$BASE_DIR/$REPO";
     git fetch --no-tags upstream && git fetch --no-tags origin;
     BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)";

--- a/scripts/push-rapids-repositories.sh
+++ b/scripts/push-rapids-repositories.sh
@@ -10,6 +10,7 @@ CODE_REPOS="${CODE_REPOS:-rmm raft cudf cuml cugraph cuspatial}"
 ALL_REPOS="${ALL_REPOS:-$CODE_REPOS notebooks-contrib}"
 
 for REPO in $ALL_REPOS; do
+    echo "Pushing $REPO..."
     cd "$BASE_DIR/$REPO";
     git push origin $(git rev-parse --abbrev-ref HEAD);
     cd - >/dev/null 2>&1;


### PR DESCRIPTION
This makes it a little easier to determine which repo was the cause of an error if something goes wrong with one of the git operations.

Background: One of my local repository states got out of sync with the scripts' expectations, so when fetching from upstream I got:

```
$ ./scripts/fetch-rapids-repositories.sh 
remote: Enumerating objects: 147, done.
remote: Counting objects: 100% (147/147), done.
remote: Compressing objects: 100% (59/59), done.
remote: Total 90 (delta 78), reused 40 (delta 30), pack-reused 0
Unpacking objects: 100% (90/90), 17.13 KiB | 417.00 KiB/s, done.
From github.com:rapidsai/cudf
   4d6ecd12ca..c6bc111a18  branch-21.12 -> upstream/branch-21.12
remote: Enumerating objects: 21, done.
remote: Counting objects: 100% (21/21), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 21 (delta 14), reused 21 (delta 14), pack-reused 0
Unpacking objects: 100% (21/21), 3.10 KiB | 264.00 KiB/s, done.
From github.com:rapidsai/cuml
   c3b5aecb4..51c41c460  branch-21.12 -> upstream/branch-21.12
   bb627b3f4..0fd3503ba  main         -> upstream/main
remote: Enumerating objects: 23, done.
remote: Counting objects: 100% (23/23), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 23 (delta 13), reused 16 (delta 13), pack-reused 0
Unpacking objects: 100% (23/23), 10.46 KiB | 135.00 KiB/s, done.
From github.com:rapidsai/cugraph
   1313e343..3af3089d  branch-21.12 -> upstream/branch-21.12
   e03e008e..84617024  main         -> upstream/main
remote: Enumerating objects: 16, done.
remote: Counting objects: 100% (16/16), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 16 (delta 12), reused 15 (delta 12), pack-reused 0
Unpacking objects: 100% (16/16), 2.08 KiB | 355.00 KiB/s, done.
From github.com:rapidsai/cuspatial
   7242157..9550f76  branch-21.12 -> upstream/branch-21.12
   7c0151b..ba20298  main         -> upstream/main
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Something went wrong, but it's not clear which repo had the problem. With this PR, the output (after running again) was:

```
$ ./scripts/fetch-rapids-repositories.sh 
Fetching rmm...
Fetching raft...
Fetching cudf...
Fetching cuml...
Fetching cugraph...
Fetching cuspatial...
Fetching notebooks-contrib...
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

and it's now clear I've got a problem with my `notebooks-contrib` repo.