### PR TITLE
Replace Python version pinnings from package environments with PYTHON_VERSION.

### DIFF
--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -35,19 +35,20 @@ find-env-file-version() {
     done
 }
 
-replace-env-cuda-toolkit-version() {
+replace-env-versions() {
     VER=$(find-env-file-version $1)
     cat "$RAPIDS_HOME/$1/conda/environments/$1_dev_cuda$VER.yml" \
   | sed -r "s/cudatoolkit=$VER/cudatoolkit=$CUDA_TOOLKIT_VERSION/g" \
-  | sed -r "s!rapidsai/label/cuda$VER!rapidsai/label/cuda$CUDA_TOOLKIT_VERSION!g"
+  | sed -r "s!rapidsai/label/cuda$VER!rapidsai/label/cuda$CUDA_TOOLKIT_VERSION!g" \
+  | sed -r "s/python[\s<>=,\.0-9]*/python=${PYTHON_VERSION}/g"
 }
 
 YMLS=()
-if [ $(should-build-rmm)       == true ]; then echo -e "$(replace-env-cuda-toolkit-version rmm)"       > rmm.yml       && YMLS+=(rmm.yml);       fi;
-if [ $(should-build-cudf)      == true ]; then echo -e "$(replace-env-cuda-toolkit-version cudf)"      > cudf.yml      && YMLS+=(cudf.yml);      fi;
-if [ $(should-build-cuml)      == true ]; then echo -e "$(replace-env-cuda-toolkit-version cuml)"      > cuml.yml      && YMLS+=(cuml.yml);      fi;
-if [ $(should-build-cugraph)   == true ]; then echo -e "$(replace-env-cuda-toolkit-version cugraph)"   > cugraph.yml   && YMLS+=(cugraph.yml);   fi;
-if [ $(should-build-cuspatial) == true ]; then echo -e "$(replace-env-cuda-toolkit-version cuspatial)" > cuspatial.yml && YMLS+=(cuspatial.yml); fi;
+if [ $(should-build-rmm)       == true ]; then echo -e "$(replace-env-versions rmm)"       > rmm.yml       && YMLS+=(rmm.yml);       fi;
+if [ $(should-build-cudf)      == true ]; then echo -e "$(replace-env-versions cudf)"      > cudf.yml      && YMLS+=(cudf.yml);      fi;
+if [ $(should-build-cuml)      == true ]; then echo -e "$(replace-env-versions cuml)"      > cuml.yml      && YMLS+=(cuml.yml);      fi;
+if [ $(should-build-cugraph)   == true ]; then echo -e "$(replace-env-versions cugraph)"   > cugraph.yml   && YMLS+=(cugraph.yml);   fi;
+if [ $(should-build-cuspatial) == true ]; then echo -e "$(replace-env-versions cuspatial)" > cuspatial.yml && YMLS+=(cuspatial.yml); fi;
 YMLS+=(rapids.yml)
 conda-merge ${YMLS[@]} > merged.yml
 

--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -40,7 +40,7 @@ replace-env-versions() {
     cat "$RAPIDS_HOME/$1/conda/environments/$1_dev_cuda$VER.yml" \
   | sed -r "s/cudatoolkit=$VER/cudatoolkit=$CUDA_TOOLKIT_VERSION/g" \
   | sed -r "s!rapidsai/label/cuda$VER!rapidsai/label/cuda$CUDA_TOOLKIT_VERSION!g" \
-  | sed -r "s/python[\s<>=,\.0-9]*/python=${PYTHON_VERSION}/g"
+  | sed -r "s/- python[<>=,\.0-9]*$/- python=${PYTHON_VERSION}/g"
 }
 
 YMLS=()


### PR DESCRIPTION
This PR permits users to specify Python versions that ignore the merged conda environment's pinnings.

I tried to build a compose environment with `PYTHON_VERSION=3.9`, which is [in the `make init` menu](https://github.com/trxcllnt/rapids-compose/blob/7e023eb7581a763cfac78612999920d12016df53/scripts/02-create-compose-env.sh#L73) even though it's not technically supported by RAPIDS packages yet (as of this writing, rmm and cudf have pinnings to `python>=3.7,<3.9`). When I tried to run `make rapids`, it failed to solve because `python>=3.7,<3.9` conflicted with `python=3.9` from the `rapids.yml` generated environment file. This actually appeared as an openssl conflict:

```
Encountered problems while solving:
  - package librdkafka-1.7.0-hc49e61c_0 requires openssl >=1.1.1l,<1.1.2a, but none of the providers can be installed
```

Resolving the Python version conflicts allowed the environment to solve properly.