### PR TITLE
Append patch release to parsed CUDA version string.

### DIFF
--- a/scripts/02-create-compose-env.sh
+++ b/scripts/02-create-compose-env.sh
@@ -51,6 +51,8 @@ GPUS_LIST="$(join-list-contents ', ' `seq 0 $((NUM_GPUS-1))`)"
 CURRENT_CUDA_VERSION="11.5.0"
 if [[ "$(which nvcc)" != "" ]]; then
     CURRENT_CUDA_VERSION="$(nvcc --version | head -n4 | tail -n1 | cut -d' ' -f5 | cut -d',' -f1)"
+    # Append a patch version ".0" to the end of the major.minor string.
+    CURRENT_CUDA_VERSION="${CURRENT_CUDA_VERSION}.0"
 fi
 
 echo "###


### PR DESCRIPTION
Resolves issue reported by @karthikeyann:

> If we use default 11.5, During build, it shows error.
>  ```
> manifest for gpuci/cuda:11.5-devel-ubuntu20.04 not found: manifest unknown: manifest unknown
> ```
> Default should be 11.5.0, not 11.5.

The `nvcc --version` output says
```
Cuda compilation tools, release 11.5, V11.5.50
```
which doesn't contain the proper version number (11.5.0) that is needed here. This PR appends a patch release `".0"` to the parsed CUDA version string.