### PR TITLE
Update Python Debug Adapter Protocol to `debugpy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ To debug tests running in the container, use the `rapids.cudf.pytest.debug`:
 make rapids.cudf.pytest.debug args="-k 'test_reindex_dataframe'"
 ```
 
-This launches pytest with `ptvsd` for debugging in VSCode.
+This launches pytest with `debugpy` for debugging in VSCode.
 
 
 ### Working interactively in the RAPIDS container

--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -1257,7 +1257,7 @@ test-python() {
         if [[ $debug != true ]]; then
             eval "set -x; pytest $args $paths";
         else
-            eval "set -x; python -m ptvsd --host 0.0.0.0 --port 5678 --wait -m pytest $args $paths";
+            eval "set -x; python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m pytest $args $paths";
         fi
     )
 }

--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -129,7 +129,7 @@
 # Commands to run each project's pytests:
 #
 # Note: These commands automatically change into the correct directory before executing `pytest`.
-# Note: Pass --debug to use with the VSCode debugger `ptvsd`. All other arguments are forwarded to pytest.
+# Note: Pass --debug to use with the VSCode debugger `debugpy`. All other arguments are forwarded to pytest.
 # Note: Arguments that end in '.py' are assumed to be pytest files used to reduce the number of tests
 #       collected on startup by pytest. These arguments will be expanded out to their full paths relative
 #       to the directory where pytests is run.
@@ -143,7 +143,7 @@
 # Usage:
 # test-cudf-python -n <num_cores>                               - Run all pytests in parallel with `pytest-xdist`
 # test-cudf-python -v -x -k 'a_test_function_name'              - Run all tests named 'a_test_function_name', be verbose, and exit on first fail
-# test-cudf-python -v -x -k 'a_test_function_name' --debug      - Run all tests named 'a_test_function_name', and start ptvsd for VSCode debugging
+# test-cudf-python -v -x -k 'a_test_function_name' --debug      - Run all tests named 'a_test_function_name', and start debugpy for VSCode debugging
 # test-cudf-python -v -x -k 'test_a or test_b' foo/test_file.py - Run all tests named 'test_a' or 'test_b' in file paths matching foo/test_file.py
 #
 ###

--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -20,7 +20,7 @@ dependencies:
 - pytest-xdist
 - python=${PYTHON_VERSION}
 - pip:
-  - ptvsd
+  - debugpy
 EOF
 
 CUDA_TOOLKIT_VERSION=${CONDA_CUDA_TOOLKIT_VERSION:-$CUDA_SHORT_VERSION};


### PR DESCRIPTION
[ptvsd](https://github.com/microsoft/ptvsd) is deprecated and superseded by [debugpy](https://github.com/microsoft/debugpy/). This PR updates that.