### PR TITLE
Add script to report status of RAPIDS repos

### DIFF
--- a/scripts/status-rapids-repositories.sh
+++ b/scripts/status-rapids-repositories.sh
@@ -25,8 +25,8 @@ CODE_REPOS="${CODE_REPOS:-rmm raft cudf cuml cugraph cuspatial}"
 ALL_REPOS="${ALL_REPOS:-$CODE_REPOS compose notebooks-contrib}"
 
 for REPO in $ALL_REPOS; do
-    echo "$REPO:"
-    cd "$BASE_DIR/$REPO";
+    echo "$REPO:";
+    pushd "$BASE_DIR/$REPO";
     git status $ARGS;
-    cd - >/dev/null 2>&1;
+    popd;
 done

--- a/scripts/status-rapids-repositories.sh
+++ b/scripts/status-rapids-repositories.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Reports on the status of each RAPIDS repository.
+#
+# By default the short form of the status is reported, along with the branch
+# name (`-s -b`) - an alternative form can be reported by providing the
+# arguments to `git status` as arguments to this script.
+
+set -Eeo pipefail
+
+if [ ! -z $1 ]
+then
+    # Use arguments for status from user
+    ARGS="$@"
+else
+    # Default arguments: short-form changes with branch
+    ARGS="-s -b"
+fi
+
+cd $(dirname "$(realpath "$0")")/../../
+
+BASE_DIR="$(pwd)"
+
+CODE_REPOS="${CODE_REPOS:-rmm raft cudf cuml cugraph cuspatial}"
+ALL_REPOS="${ALL_REPOS:-$CODE_REPOS compose notebooks-contrib}"
+
+for REPO in $ALL_REPOS; do
+    echo "$REPO:"
+    cd "$BASE_DIR/$REPO";
+    git status $ARGS;
+    cd - >/dev/null 2>&1;
+done


### PR DESCRIPTION
Inspired by the [`repo status`](https://source.android.com/setup/develop/repo#status) command.

By default the short form of the status is reported, along with the branch name (`-s -b`) - an alternative form can be reported by providing the arguments to `git status` as arguments to this script.

Some use cases I have for this are:

- To quickly see if I'm a long way behind upstream after running `scripts/fetch-rapids-repositories.sh`,
- prior to switching branches to check I don't have any local modifications anywhere,
- when I come back to some work after a break to remind myself of what's in-flight.

Example output:

![status-example](https://user-images.githubusercontent.com/535640/151152731-1125f827-70ba-47d0-9f31-932089c17b0c.png)
