### PR TITLE
Ubuntu 22.04 support

### DIFF
--- a/dockerfiles/rapids.Dockerfile
+++ b/dockerfiles/rapids.Dockerfile
@@ -48,7 +48,8 @@ fi' \
     # This provides the `nsight-sys` GUI
     cuda-nsight-systems-${NSIGHT_CUDA_VERSION} \
     # Needed by `nsight-sys` GUI
-    qt5-default libglvnd-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev \
+    qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+    libglvnd-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev \
     libglib2.0-0 \
     libsqlite3-0 \
     xcb \

--- a/dockerfiles/rapids.Dockerfile
+++ b/dockerfiles/rapids.Dockerfile
@@ -41,8 +41,8 @@ fi' \
     # for building cudf-java
     maven openjdk-8-jdk openjdk-8-jdk-headless openjdk-8-jre openjdk-8-jre-headless \
     # Install nsight-compute and nsight-systems
-    nsight-compute-2021.3.0 \
-    nsight-systems-2021.3.3 \
+    nsight-compute-2022.2.0 \
+    nsight-systems-2022.1.3 \
     # Not sure what this is but it seems important
     cuda-nsight-compute-${NSIGHT_CUDA_VERSION} \
     # This provides the `nsight-sys` GUI


### PR DESCRIPTION
This PR updates some apt package names so that rapids-compose can be used with Ubuntu 22.04.

The changes are:
- New versions of nsight-compute and nsight-systems that are available for 18.04, 20.04, 22.04.
- Replaced `qt5-default` with `qtbase5-dev`, `qtchooser`, `qt5-qmake`, `qtbase5-dev-tools` because `qt5-default` is not available in 22.04. See: https://askubuntu.com/questions/1335184/qt5-default-not-in-ubuntu-21-04

I verified that Docker images can be built with Ubuntu 22.04 and Ubuntu 20.04, using CUDA 11.7.0 as the base image and conda cudatoolkit 11.6 (11.7 is not yet available on conda-forge).