### PR TITLE
Use Mambaforge distribution of conda

### DIFF
--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -89,7 +89,7 @@ elif [ -n "${CHANGED// }" ]; then
     # print the diff to the console for debugging
     diff -wy $OUTSIDE_ENV_YML $INSIDE__ENV_YML || true
     # update the existing environment
-    conda update -n base -c defaults conda
+    conda update -n base -c conda-forge conda
     conda update -n base -c conda-forge mamba
     mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || CONDA_ENV_UPDATE_FAILED=1
     if [ "$CONDA_ENV_UPDATE_FAILED" -eq "0" ]; then

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -20,7 +20,6 @@ if [[ "$(which conda)" == "" ]]; then
     chmod +x "$RAPIDS_HOME/mambaforge.sh" && "$RAPIDS_HOME/mambaforge.sh" -f -b -p "$CONDA_HOME" && rm "$RAPIDS_HOME/mambaforge.sh"
     conda config --system --set always_yes yes
     conda config --system --set changeps1 False
-    conda config --system --remove channels defaults
 fi
 
 if [[ "$(which mamba)" == "" ]]; then
@@ -59,8 +58,8 @@ RECREATE_CONDA_ENV=0
 
 create-conda-env() {
     # create a new environment
-    mamba update -n base -c defaults conda
     mamba update -n base -c conda-forge mamba
+    mamba update -n base -c conda-forge conda
     mamba env create -n $ENV_NAME --file $INSIDE__ENV_YML
     # copy the conda environment.yml from inside the container to the outside
     cp $INSIDE__ENV_YML $OUTSIDE_ENV_YML
@@ -89,8 +88,8 @@ elif [ -n "${CHANGED// }" ]; then
     # print the diff to the console for debugging
     diff -wy $OUTSIDE_ENV_YML $INSIDE__ENV_YML || true
     # update the existing environment
-    mamba update -n base -c defaults conda
     mamba update -n base -c conda-forge mamba
+    mamba update -n base -c conda-forge conda
     mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || CONDA_ENV_UPDATE_FAILED=1
     if [ "$CONDA_ENV_UPDATE_FAILED" -eq "0" ]; then
         # copy the conda environment.yml from inside the container to the outside

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -59,7 +59,7 @@ RECREATE_CONDA_ENV=0
 
 create-conda-env() {
     # create a new environment
-    conda update -n base -c defaults conda
+    conda update -n base -c conda-forge conda
     conda update -n base -c conda-forge mamba
     mamba env create -n $ENV_NAME --file $INSIDE__ENV_YML
     # copy the conda environment.yml from inside the container to the outside

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -23,10 +23,6 @@ if [[ "$(which conda)" == "" ]]; then
     conda config --system --remove channels defaults
 fi
 
-if [[ "$(which mamba)" == "" ]]; then
-    conda install -n base -c conda-forge mamba
-fi
-
 ####
 # Diff the conda environment.yml file created when the container was built
 # against the environment.yml that exists in the container's volume mount.
@@ -60,7 +56,7 @@ RECREATE_CONDA_ENV=0
 create-conda-env() {
     # create a new environment
     conda update -n base -c conda-forge conda
-    conda update -n base -c conda-forge mamba
+    conda install -n base -c conda-forge mamba
     mamba env create -n $ENV_NAME --file $INSIDE__ENV_YML
     # copy the conda environment.yml from inside the container to the outside
     cp $INSIDE__ENV_YML $OUTSIDE_ENV_YML
@@ -89,9 +85,9 @@ elif [ -n "${CHANGED// }" ]; then
     # print the diff to the console for debugging
     diff -wy $OUTSIDE_ENV_YML $INSIDE__ENV_YML || true
     # update the existing environment
-    conda update -n base -c conda-forge conda
-    conda update -n base -c conda-forge mamba
-    mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || CONDA_ENV_UPDATE_FAILED=1
+    conda update -n base -c conda-forge conda mamba && \
+        mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || \
+        CONDA_ENV_UPDATE_FAILED=1
     if [ "$CONDA_ENV_UPDATE_FAILED" -eq "0" ]; then
         # copy the conda environment.yml from inside the container to the outside
         cp $INSIDE__ENV_YML $OUTSIDE_ENV_YML
@@ -114,6 +110,7 @@ elif [ -n "${CHANGED// }" ]; then
 fi
 
 if [ "$RECREATE_CONDA_ENV" -eq "1" ]; then
+    conda remove -n base mamba
     mamba env remove --name $ENV_NAME
     FRESH_CONDA_ENV=1
     create-conda-env

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -59,8 +59,8 @@ RECREATE_CONDA_ENV=0
 
 create-conda-env() {
     # create a new environment
-    mamba update -n base -c defaults conda
-    mamba update -n base -c conda-forge mamba
+    conda update -n base -c defaults conda
+    conda update -n base -c conda-forge mamba
     mamba env create -n $ENV_NAME --file $INSIDE__ENV_YML
     # copy the conda environment.yml from inside the container to the outside
     cp $INSIDE__ENV_YML $OUTSIDE_ENV_YML
@@ -89,8 +89,8 @@ elif [ -n "${CHANGED// }" ]; then
     # print the diff to the console for debugging
     diff -wy $OUTSIDE_ENV_YML $INSIDE__ENV_YML || true
     # update the existing environment
-    mamba update -n base -c defaults conda
-    mamba update -n base -c conda-forge mamba
+    conda update -n base -c defaults conda
+    conda update -n base -c conda-forge mamba
     mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || CONDA_ENV_UPDATE_FAILED=1
     if [ "$CONDA_ENV_UPDATE_FAILED" -eq "0" ]; then
         # copy the conda environment.yml from inside the container to the outside

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -115,7 +115,6 @@ elif [ -n "${CHANGED// }" ]; then
 fi
 
 if [ "$RECREATE_CONDA_ENV" -eq "1" ]; then
-    conda install -n base mamba --force-reinstall
     mamba env remove --name $ENV_NAME
     FRESH_CONDA_ENV=1
     create-conda-env

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -16,8 +16,8 @@ mkdir -p "$CONDA_HOME"
 
 # ensure conda's installed
 if [[ "$(which conda)" == "" ]]; then
-    curl -s -o "$RAPIDS_HOME/miniconda.sh" -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-    chmod +x "$RAPIDS_HOME/miniconda.sh" && "$RAPIDS_HOME/miniconda.sh" -f -b -p "$CONDA_HOME" && rm "$RAPIDS_HOME/miniconda.sh"
+    curl -s -o "$RAPIDS_HOME/mambaforge.sh" -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh
+    chmod +x "$RAPIDS_HOME/mambaforge.sh" && "$RAPIDS_HOME/mambaforge.sh" -f -b -p "$CONDA_HOME" && rm "$RAPIDS_HOME/mambaforge.sh"
     conda config --system --set always_yes yes
     conda config --system --set changeps1 False
     conda config --system --remove channels defaults

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -111,7 +111,7 @@ fi
 
 if [ "$RECREATE_CONDA_ENV" -eq "1" ]; then
     conda remove -n base mamba
-    mamba env remove --name $ENV_NAME
+    conda env remove --name $ENV_NAME
     FRESH_CONDA_ENV=1
     create-conda-env
 fi


### PR DESCRIPTION
This updates rapids-compose to use the Mambaforge distribution of conda. By default, this distribution does not add the `defaults` channel and uses conda-forge instead. Additionally, it comes with `mamba` pre-installed. (Hence the name.)

I also changed the commands updating mamba/conda so that mamba is always updated first, to prevent this current issue: https://github.com/mamba-org/mamba/issues/1706

Tested locally with a fresh conda environment (`rm -rf etc/conda` to clean the existing environments). Existing conda environments built from miniconda should be unharmed by these changes, as far as I am aware.