### PR TITLE
Add handling for failed conda/mamba update

### DIFF
--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -89,7 +89,7 @@ elif [ -n "${CHANGED// }" ]; then
     # print the diff to the console for debugging
     diff -wy $OUTSIDE_ENV_YML $INSIDE__ENV_YML || true
     # update the existing environment
-    conda update -n base -c defaults conda
+    conda update -n base -c conda-forge conda
     conda update -n base -c conda-forge mamba
     mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || CONDA_ENV_UPDATE_FAILED=1
     if [ "$CONDA_ENV_UPDATE_FAILED" -eq "0" ]; then

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -59,7 +59,7 @@ RECREATE_CONDA_ENV=0
 
 create-conda-env() {
     # create a new environment
-    conda update -n base -c defaults conda
+    conda update -n base -c conda-forge conda
     conda update -n base -c conda-forge mamba
     mamba env create -n $ENV_NAME --file $INSIDE__ENV_YML
     # copy the conda environment.yml from inside the container to the outside

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -23,10 +23,6 @@ if [[ "$(which conda)" == "" ]]; then
     conda config --system --remove channels defaults
 fi
 
-if [[ "$(which mamba)" == "" ]]; then
-    conda install -n base -c conda-forge mamba
-fi
-
 ####
 # Diff the conda environment.yml file created when the container was built
 # against the environment.yml that exists in the container's volume mount.
@@ -60,7 +56,7 @@ RECREATE_CONDA_ENV=0
 create-conda-env() {
     # create a new environment
     conda update -n base -c conda-forge conda
-    conda update -n base -c conda-forge mamba
+    conda install -n base -c conda-forge mamba
     mamba env create -n $ENV_NAME --file $INSIDE__ENV_YML
     # copy the conda environment.yml from inside the container to the outside
     cp $INSIDE__ENV_YML $OUTSIDE_ENV_YML
@@ -89,9 +85,9 @@ elif [ -n "${CHANGED// }" ]; then
     # print the diff to the console for debugging
     diff -wy $OUTSIDE_ENV_YML $INSIDE__ENV_YML || true
     # update the existing environment
-    conda update -n base -c conda-forge conda
-    conda update -n base -c conda-forge mamba
-    mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || CONDA_ENV_UPDATE_FAILED=1
+    conda update -n base -c conda-forge conda mamba && \
+        mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || \
+        CONDA_ENV_UPDATE_FAILED=1
     if [ "$CONDA_ENV_UPDATE_FAILED" -eq "0" ]; then
         # copy the conda environment.yml from inside the container to the outside
         cp $INSIDE__ENV_YML $OUTSIDE_ENV_YML
@@ -114,6 +110,7 @@ elif [ -n "${CHANGED// }" ]; then
 fi
 
 if [ "$RECREATE_CONDA_ENV" -eq "1" ]; then
+    conda remove -n base mamba
     mamba env remove --name $ENV_NAME
     FRESH_CONDA_ENV=1
     create-conda-env

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -59,8 +59,8 @@ RECREATE_CONDA_ENV=0
 
 create-conda-env() {
     # create a new environment
-    mamba update -n base -c defaults conda
-    mamba update -n base -c conda-forge mamba
+    conda update -n base -c defaults conda
+    conda update -n base -c conda-forge mamba
     mamba env create -n $ENV_NAME --file $INSIDE__ENV_YML
     # copy the conda environment.yml from inside the container to the outside
     cp $INSIDE__ENV_YML $OUTSIDE_ENV_YML
@@ -89,8 +89,8 @@ elif [ -n "${CHANGED// }" ]; then
     # print the diff to the console for debugging
     diff -wy $OUTSIDE_ENV_YML $INSIDE__ENV_YML || true
     # update the existing environment
-    mamba update -n base -c defaults conda
-    mamba update -n base -c conda-forge mamba
+    conda update -n base -c defaults conda
+    conda update -n base -c conda-forge mamba
     mamba env update -n $ENV_NAME --file $INSIDE__ENV_YML --prune || CONDA_ENV_UPDATE_FAILED=1
     if [ "$CONDA_ENV_UPDATE_FAILED" -eq "0" ]; then
         # copy the conda environment.yml from inside the container to the outside

--- a/etc/conda-install.sh
+++ b/etc/conda-install.sh
@@ -111,7 +111,7 @@ fi
 
 if [ "$RECREATE_CONDA_ENV" -eq "1" ]; then
     conda remove -n base mamba
-    mamba env remove --name $ENV_NAME
+    conda env remove --name $ENV_NAME
     FRESH_CONDA_ENV=1
     create-conda-env
 fi


### PR DESCRIPTION
This PR resolves some of the recent issues around conda/mamba by:
- Switching the install/update of `conda`/`mamba` to use `conda` to avoid potential mismatched version errors
- Adding handling for the case when `conda`/`mamba` fail to get updated in the `base` environment, sending users to the failure prompt
- Making `mamba` removal/re-installation a part of the `R` option for when the conda environment update fails, which should generally resolve any failures associated with updating `mamba`

I've also switched over to the conda-forge `conda` package (if we switch over to [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) we can probably remove this)