### PR TITLE
Make the .vscode directory before outputting c_cpp_properties.json.

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -1348,6 +1348,7 @@ fix-nvcc-clangd-compile-commands() {
 
         mv "$CC_JSON" "$CC_JSON.orig";
 
+        mkdir -p "$CPP_DIR/.vscode"
         cat << EOF > "$CPP_DIR/.vscode/c_cpp_properties.json"
 {
     "version": 4,


### PR DESCRIPTION
I sometimes see this error when building. It happens when the directory `.vscode` has not yet been created. This PR adds a `mkdir -p .vscode` to prevent the problem.
```
-bash: /home/bdice/rapids1/cuspatial/cpp/.vscode/c_cpp_properties.json: No such file or directory
```