### PR TITLE
Use nvcc_linux-64 version matching CONDA_CUDA_TOOLKIT_VERSION.

### DIFF
--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -39,6 +39,7 @@ replace-env-versions() {
     VER=$(find-env-file-version $1)
     cat "$RAPIDS_HOME/$1/conda/environments/$1_dev_cuda$VER.yml" \
   | sed -r "s/cudatoolkit=$VER/cudatoolkit=$CUDA_TOOLKIT_VERSION/g" \
+  | sed -r "s/nvcc_linux-64=$VER/nvcc_linux-64=$CUDA_TOOLKIT_VERSION/g" \
   | sed -r "s!rapidsai/label/cuda$VER!rapidsai/label/cuda$CUDA_TOOLKIT_VERSION!g" \
   | sed -r "s/- python[<>=,\.0-9]*$/- python=${PYTHON_VERSION}/g"
 }


### PR DESCRIPTION
This PR fixes the warning `Version of installed CUDA didn't match package`.

This arises from the conda-forge nvcc package's activation script: https://github.com/conda-forge/nvcc-feedstock/blob/4acf86c13bfd9a828d3e44c1cd9e1255d0474f73/recipe/install_nvcc.sh#L66-L70

We replace the `cudatoolkit` version with a user-specified pinning, and we should use the same version for `nvcc_linux-64` to avoid this warning. This warning began after https://github.com/rapidsai/cudf/pull/11154 added `nvcc_linux-64` to the conda environment for cudf.