### PR TITLE
Support opening a host terminal

### DIFF
--- a/scripts/03-create-vscode-workspace.sh
+++ b/scripts/03-create-vscode-workspace.sh
@@ -271,6 +271,10 @@ cat << EOF
                 "path": "/bin/bash",
                 "icon": "terminal-bash",
                 "args": ["-c", "rapids_container=\$(docker ps | grep rapidsai/\$(whoami)/rapids | cut -d\" \" -f1 || echo \"\"); if [ \"\$rapids_container\" == \"\" ]; then exec \$SHELL; else exec docker exec -u \${UID}:\${GID} -it -w \"\$PWD\" \"\$rapids_container\" bash -li; fi"]
+            },
+            "bash-host": {
+                "path": "/bin/bash",
+                "icon": "terminal-bash"
             }
         },
         "terminal.integrated.automationProfile.linux": {


### PR DESCRIPTION
If the docker container is running right now, there is no way to open a host terminal inside VSCode.
This change adds a second terminal profile allowing people to choose where to open the terminal.
I'm not sure if it's necessary to set a default, but my VSCode still defaults to the dockerized `bash`.
For details, see https://code.visualstudio.com/docs/terminal/basics#_terminal-profiles