### PR TITLE
Have cuspatial CPP find pre-built cudf.

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -527,7 +527,7 @@ export -f build-cugraph-python;
 build-cuspatial-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building cuspatial";
-    build-python-new "$CUSPATIAL_HOME/python/cuspatial" "CUSPATIAL";
+    build-python-new "$CUSPATIAL_HOME/python/cuspatial" "CUSPATIAL" "-Dcudf_ROOT=${CUDF_ROOT_ABS}";
 }
 
 export -f build-cuspatial-python;


### PR DESCRIPTION
This ensures that cuspatial Python knows where to find libcudf. libcudf is part of libcuspatial's public link interface, so we need to make sure that libcudf is on the library search path when building the Python lib (which links to libcuspatial).