### PR TITLE
Use uid, gid ofhost unix account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ dc:
 		PYTHON_VERSION=$${PYTHON_VERSION:-$(DEFAULT_PYTHON_VERSION)} \
 		RAPIDS_NAMESPACE=$${RAPIDS_NAMESPACE:-$(DEFAULT_RAPIDS_NAMESPACE)} \
 		CONDA_CUDA_TOOLKIT_VERSION=$${CONDA_CUDA_TOOLKIT_VERSION:-$$CUDA_VERSION} \
-		docker-compose -f $(file) $(cmd) $(cmd_args) $(svc) $(svc_args)
+		docker compose -f $(file) $(cmd) $(cmd_args) $(svc) $(svc_args)
 
 init:
 	export CODE_REPOS="rmm raft cudf cuml cugraph cuspatial" && \

--- a/dockerfiles/rapids.Dockerfile
+++ b/dockerfiles/rapids.Dockerfile
@@ -148,15 +148,21 @@ ENV CUGRAPH_HOME="$RAPIDS_HOME/cugraph"
 ENV CUSPATIAL_HOME="$RAPIDS_HOME/cuspatial"
 ENV NOTEBOOKS_CONTRIB_HOME="$RAPIDS_HOME/notebooks-contrib"
 
+ARG UID
+ARG GID
+ENV UID="$UID"
+ENV GID="$GID"
+
 RUN mkdir -p /var/log "$RAPIDS_HOME" "$CONDA_HOME" \
              "$RAPIDS_HOME" "$RAPIDS_HOME/.conda" "$RAPIDS_HOME/notebooks" \
  # Symlink to root so we have an easy entrypoint from external scripts
  && ln -s "$RAPIDS_HOME" /rapids \
- && adduser \
-    --gecos '' \
+ && groupadd -g $GID -o rapids \
+ && useradd \
+    --uid $UID --gid $GID --no-log-init \
     --shell /bin/bash \
-    --home "$RAPIDS_HOME" \
-    --disabled-password rapids \
+    --home-dir "$RAPIDS_HOME" \
+    rapids \
  && echo "rapids ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd \
  && chmod 0777 /tmp \
  && chown -R rapids:rapids "$RAPIDS_HOME" "$CONDA_HOME" \


### PR DESCRIPTION
Fixes permission issues with non-local host unix account with non-default uid, gid `1000` --no-log-init is required to prevent building huge log-init file. else docker will run out of disk memory.