### PR TITLE
Update channel priority.

### DIFF
--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -15,9 +15,9 @@ cat << EOF > rapids.yml
 name: rapids
 channels:
 - rapidsai
-- nvidia
 - rapidsai-nightly
 - conda-forge
+- nvidia
 dependencies:
 - cmake>=3.20
 - cmake_setuptools
@@ -98,10 +98,9 @@ cat << EOF > notebooks.yml
 name: notebooks
 channels:
 - rapidsai
-- nvidia
 - rapidsai-nightly
-# - numba
 - conda-forge
+- nvidia
 dependencies:
 - bokeh
 - dask-labextension


### PR DESCRIPTION
We need to put `nvidia` below `conda-forge` in our channel priority, following the 22.10.01 hotfixes/updates for `cuda-python`. Without this fix, the conda merge script fails because it cannot prioritize the channels consistently.