### PR TITLE
Improve cugraph support

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -700,15 +700,24 @@ clean-cugraph-python() {
     print-heading "Cleaning cugraph";
     rm -rf "$CUGRAPH_HOME/python/cugraph/dist" \
            "$CUGRAPH_HOME/python/cugraph/build" \
+           "$CUGRAPH_HOME/python/cugraph/_skbuild" \
            "$CUGRAPH_HOME/python/cugraph/.hypothesis" \
-           "$CUGRAPH_HOME/python/cugraph/cugraph/raft" \
            "$CUGRAPH_HOME/python/cugraph/.pytest_cache" \
            "$CUGRAPH_HOME/python/cugraph/_external_repositories" \
            "$CUGRAPH_HOME/python/cugraph/dask-worker-space";
+    rm -rf "$CUGRAPH_HOME/python/pylibcugraph/dist" \
+           "$CUGRAPH_HOME/python/pylibcugraph/build" \
+           "$CUGRAPH_HOME/python/pylibcugraph/_skbuild" \
+           "$CUGRAPH_HOME/python/pylibcugraph/.hypothesis" \
+           "$CUGRAPH_HOME/python/pylibcugraph/.pytest_cache" \
+           "$CUGRAPH_HOME/python/pylibcugraph/_external_repositories" \
+           "$CUGRAPH_HOME/python/pylibcugraph/dask-worker-space";
     find "$CUGRAPH_HOME" -type f -name '*.pyc' -delete;
     find "$CUGRAPH_HOME" -type d -name '__pycache__' -delete;
     find "$CUGRAPH_HOME/python/cugraph" -type f -name '*.so' -delete;
     find "$CUGRAPH_HOME/python/cugraph" -type f -name '*.cpp' -delete;
+    find "$CUGRAPH_HOME/python/pylibcugraph" -type f -name '*.so' -delete;
+    find "$CUGRAPH_HOME/python/pylibcugraph" -type f -name '*.cpp' -delete;
 }
 
 export -f clean-cugraph-python;

--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -243,6 +243,7 @@ cuSpatial: $(should-build-cuspatial $@)";
         if [ $(should-build-raft) == true ]; then build-raft-dask-python $@ || exit 1; fi;
         if [ $(should-build-cudf) == true ]; then build-cudf-python $@ || exit 1; fi;
         if [ $(should-build-cuml) == true ]; then build-cuml-python $@ || exit 1; fi;
+        if [ $(should-build-cugraph) == true ]; then build-pylibcugraph-python $@ || exit 1; fi;
         if [ $(should-build-cugraph) == true ]; then build-cugraph-python $@ || exit 1; fi;
         if [ $(should-build-cuspatial) == true ]; then build-cuspatial-python $@ || exit 1; fi;
     )
@@ -280,6 +281,7 @@ cuSpatial: $(should-build-cuspatial $@)";
         run-in-background "if [ \$(should-build-raft) == true ]; then clean-raft-dask-python $@; fi"
         run-in-background "if [ \$(should-build-raft) == true ]; then clean-pylibraft-python $@; fi"
         run-in-background "if [ \$(should-build-cuml) == true ]; then clean-cuml-python $@; fi"
+        run-in-background "if [ \$(should-build-cugraph) == true ]; then clean-pylibcugraph-python $@; fi"
         run-in-background "if [ \$(should-build-cugraph) == true ]; then clean-cugraph-python $@; fi"
         run-in-background "if [ \$(should-build-cuspatial) == true ]; then clean-cuspatial-python $@; fi"
 
@@ -530,11 +532,18 @@ build-cuml-python() {
 
 export -f build-cuml-python;
 
-build-cugraph-python() {
+build-pylibcugraph-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building cugraph";
     build-python-new "$CUGRAPH_HOME/python/pylibcugraph" "CUGRAPH" \
         "-Draft_ROOT=${RAFT_ROOT_ABS} -DUSE_CUGRAPH_OPS=OFF";
+}
+
+export -f build-pylibcugraph-python;
+
+build-cugraph-python() {
+    update-environment-variables $@ >/dev/null;
+    print-heading "Building cugraph";
     build-python-new "$CUGRAPH_HOME/python/cugraph" "CUGRAPH" \
         "-Draft_ROOT=${RAFT_ROOT_ABS}-DUSE_CUGRAPH_OPS=OFF";
 }
@@ -695,6 +704,24 @@ clean-cuml-python() {
 
 export -f clean-cuml-python;
 
+clean-pylibcugraph-python() {
+    update-environment-variables $@ >/dev/null;
+    print-heading "Cleaning pylibcugraph";
+    rm -rf "$CUGRAPH_HOME/python/pylibcugraph/dist" \
+           "$CUGRAPH_HOME/python/pylibcugraph/build" \
+           "$CUGRAPH_HOME/python/pylibcugraph/_skbuild" \
+           "$CUGRAPH_HOME/python/pylibcugraph/.hypothesis" \
+           "$CUGRAPH_HOME/python/pylibcugraph/.pytest_cache" \
+           "$CUGRAPH_HOME/python/pylibcugraph/_external_repositories" \
+           "$CUGRAPH_HOME/python/pylibcugraph/dask-worker-space";
+    find "$CUGRAPH_HOME/python/pylibcugraph" -type f -name '*.pyc' -delete;
+    find "$CUGRAPH_HOME/python/pylibcugraph" -type d -name '__pycache__' -delete;
+    find "$CUGRAPH_HOME/python/pylibcugraph" -type f -name '*.so' -delete;
+    find "$CUGRAPH_HOME/python/pylibcugraph" -type f -name '*.cpp' -delete;
+}
+
+export -f clean-pylibcugraph-python;
+
 clean-cugraph-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Cleaning cugraph";
@@ -705,19 +732,10 @@ clean-cugraph-python() {
            "$CUGRAPH_HOME/python/cugraph/.pytest_cache" \
            "$CUGRAPH_HOME/python/cugraph/_external_repositories" \
            "$CUGRAPH_HOME/python/cugraph/dask-worker-space";
-    rm -rf "$CUGRAPH_HOME/python/pylibcugraph/dist" \
-           "$CUGRAPH_HOME/python/pylibcugraph/build" \
-           "$CUGRAPH_HOME/python/pylibcugraph/_skbuild" \
-           "$CUGRAPH_HOME/python/pylibcugraph/.hypothesis" \
-           "$CUGRAPH_HOME/python/pylibcugraph/.pytest_cache" \
-           "$CUGRAPH_HOME/python/pylibcugraph/_external_repositories" \
-           "$CUGRAPH_HOME/python/pylibcugraph/dask-worker-space";
-    find "$CUGRAPH_HOME" -type f -name '*.pyc' -delete;
-    find "$CUGRAPH_HOME" -type d -name '__pycache__' -delete;
+    find "$CUGRAPH_HOME/python/cugraph" -type f -name '*.pyc' -delete;
+    find "$CUGRAPH_HOME/python/cugraph" -type d -name '__pycache__' -delete;
     find "$CUGRAPH_HOME/python/cugraph" -type f -name '*.so' -delete;
     find "$CUGRAPH_HOME/python/cugraph" -type f -name '*.cpp' -delete;
-    find "$CUGRAPH_HOME/python/pylibcugraph" -type f -name '*.so' -delete;
-    find "$CUGRAPH_HOME/python/pylibcugraph" -type f -name '*.cpp' -delete;
 }
 
 export -f clean-cugraph-python;

--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -534,9 +534,9 @@ build-cugraph-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building cugraph";
     build-python-new "$CUGRAPH_HOME/python/pylibcugraph" "CUGRAPH" \
-        "-Draft_ROOT=${RAFT_ROOT_ABS}";
+        "-Draft_ROOT=${RAFT_ROOT_ABS} -DUSE_CUGRAPH_OPS=OFF";
     build-python-new "$CUGRAPH_HOME/python/cugraph" "CUGRAPH" \
-        "-Draft_ROOT=${RAFT_ROOT_ABS}";
+        "-Draft_ROOT=${RAFT_ROOT_ABS}-DUSE_CUGRAPH_OPS=OFF";
 }
 
 export -f build-cugraph-python;

--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -534,7 +534,7 @@ export -f build-cuml-python;
 
 build-pylibcugraph-python() {
     update-environment-variables $@ >/dev/null;
-    print-heading "Building cugraph";
+    print-heading "Building pylibcugraph";
     build-python-new "$CUGRAPH_HOME/python/pylibcugraph" "CUGRAPH" \
         "-Draft_ROOT=${RAFT_ROOT_ABS} -DUSE_CUGRAPH_OPS=OFF";
 }
@@ -545,7 +545,7 @@ build-cugraph-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building cugraph";
     build-python-new "$CUGRAPH_HOME/python/cugraph" "CUGRAPH" \
-        "-Draft_ROOT=${RAFT_ROOT_ABS}-DUSE_CUGRAPH_OPS=OFF";
+        "-Draft_ROOT=${RAFT_ROOT_ABS} -DUSE_CUGRAPH_OPS=OFF";
 }
 
 export -f build-cugraph-python;


### PR DESCRIPTION
This PR makes some quality of life improvements for cugraph:
- It separates pylibcugraph and cugraph builds so that they can be built separately
- It separates pylibcugraph and cugraph cleaning so that they can be cleaned separately
- It updates the cleaning logic so that all the necessary files are removed (in particular, it ensures that the `_skbuild` directories are cleaned).