### PR TITLE
Switch raft builds to use the dfg version of the env file.

### DIFF
--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -73,7 +73,7 @@ replace-env-versions-dfg() {
 
 YMLS=()
 if [ $(should-build-rmm)       == true ]; then echo -e "$(replace-env-versions-dfg rmm)"   > rmm.yml       && YMLS+=(rmm.yml);       fi;
-if [ $(should-build-raft)      == true ]; then echo -e "$(replace-env-versions raft)"      > raft.yml      && YMLS+=(raft.yml);      fi;
+if [ $(should-build-raft)      == true ]; then echo -e "$(replace-env-versions-dfg raft)"      > raft.yml      && YMLS+=(raft.yml);      fi;
 if [ $(should-build-cudf)      == true ]; then echo -e "$(replace-env-versions-dfg cudf)"  > cudf.yml      && YMLS+=(cudf.yml);      fi;
 if [ $(should-build-cuml)      == true ]; then echo -e "$(replace-env-versions cuml)"      > cuml.yml      && YMLS+=(cuml.yml);      fi;
 if [ $(should-build-cugraph)   == true ]; then echo -e "$(replace-env-versions cugraph)"   > cugraph.yml   && YMLS+=(cugraph.yml);   fi;


### PR DESCRIPTION
[raft's dependencies.yaml file PR is now merged](https://github.com/rapidsai/raft/pull/1065), so compose needs to pull its requirements from there.