### PR TITLE
Clean out cruft

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -499,7 +499,7 @@ export -f build-cuspatial-cpp;
 build-rmm-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building rmm";
-    build-python-new "$RMM_HOME/python" "RMM";
+    build-python "$RMM_HOME/python" "RMM";
 }
 
 export -f build-rmm-python;
@@ -507,7 +507,7 @@ export -f build-rmm-python;
 build-cudf-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building cudf";
-    build-python-new "$CUDF_HOME/python/cudf" "CUDF";
+    build-python "$CUDF_HOME/python/cudf" "CUDF";
 }
 
 export -f build-cudf-python;
@@ -515,7 +515,7 @@ export -f build-cudf-python;
 build-pylibraft-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building raft";
-    build-python-new "$RAFT_HOME/python/pylibraft" "RAFT";
+    build-python "$RAFT_HOME/python/pylibraft" "RAFT";
 }
 
 export -f build-pylibraft-python;
@@ -523,7 +523,7 @@ export -f build-pylibraft-python;
 build-raft-dask-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building raft";
-    build-python-new "$RAFT_HOME/python/raft-dask" "RAFT";
+    build-python "$RAFT_HOME/python/raft-dask" "RAFT";
 }
 
 export -f build-raft-dask-python;
@@ -531,7 +531,7 @@ export -f build-raft-dask-python;
 build-cuml-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building cuml";
-    build-python-new "$CUML_HOME/python" "CUML" \
+    build-python "$CUML_HOME/python" "CUML" \
         "-Draft_ROOT=${RAFT_ROOT_ABS}";
 }
 
@@ -540,7 +540,7 @@ export -f build-cuml-python;
 build-pylibcugraph-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building pylibcugraph";
-    build-python-new "$CUGRAPH_HOME/python/pylibcugraph" "CUGRAPH" \
+    build-python "$CUGRAPH_HOME/python/pylibcugraph" "CUGRAPH" \
         "-Draft_ROOT=${RAFT_ROOT_ABS} -DUSE_CUGRAPH_OPS=OFF";
 }
 
@@ -549,7 +549,7 @@ export -f build-pylibcugraph-python;
 build-cugraph-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building cugraph";
-    build-python-new "$CUGRAPH_HOME/python/cugraph" "CUGRAPH" \
+    build-python "$CUGRAPH_HOME/python/cugraph" "CUGRAPH" \
         "-Draft_ROOT=${RAFT_ROOT_ABS} -DUSE_CUGRAPH_OPS=OFF";
 }
 
@@ -558,7 +558,7 @@ export -f build-cugraph-python;
 build-cuspatial-python() {
     update-environment-variables $@ >/dev/null;
     print-heading "Building cuspatial";
-    build-python-new "$CUSPATIAL_HOME/python/cuspatial" "CUSPATIAL" "-Dcudf_ROOT=${CUDF_ROOT_ABS}";
+    build-python "$CUSPATIAL_HOME/python/cuspatial" "CUSPATIAL" "-Dcudf_ROOT=${CUDF_ROOT_ABS}";
 }
 
 export -f build-cuspatial-python;
@@ -1087,34 +1087,6 @@ build-python() {
         export CONDA_PREFIX_="$CONDA_PREFIX";
         unset CONDA_PREFIX;
 
-        time env \
-             RAFT_PATH="$RAFT_HOME" \
-             CFLAGS="${CMAKE_C_FLAGS:+$CMAKE_C_FLAGS }$CYTHON_FLAGS" \
-             CXXFLAGS="${CMAKE_CXX_FLAGS:+$CMAKE_CXX_FLAGS }$CYTHON_FLAGS" \
-             python setup.py build_ext -j${PARALLEL_LEVEL} ${@:2};
-
-        export CONDA_PREFIX="$CONDA_PREFIX_";
-        unset CONDA_PREFIX_;
-
-        rm -rf ./*.egg-info ./.eggs;
-    )
-}
-
-export -f build-python;
-
-# Once all RAPIDS packages are transitioned to scikit-build we can remove the old build-python
-build-python-new() {
-    (
-        cd "$1";
-
-        CYTHON_FLAGS="${CYTHON_FLAGS:-}";
-        CYTHON_FLAGS="${CYTHON_FLAGS:+$CYTHON_FLAGS }-Wno-reorder";
-        CYTHON_FLAGS="${CYTHON_FLAGS:+$CYTHON_FLAGS }-Wno-unknown-pragmas";
-        CYTHON_FLAGS="${CYTHON_FLAGS:+$CYTHON_FLAGS }-Wno-unused-variable";
-
-        export CONDA_PREFIX_="$CONDA_PREFIX";
-        unset CONDA_PREFIX;
-
         prefix_path=${2}_ROOT
         time env \
              CFLAGS="${CMAKE_C_FLAGS:+$CMAKE_C_FLAGS }$CYTHON_FLAGS" \
@@ -1134,7 +1106,7 @@ build-python-new() {
     )
 }
 
-export -f build-python-new;
+export -f build-python;
 
 docs-cpp() {
     (

--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -95,7 +95,7 @@ conda-merge ${YMLS[@]} > merged.yml
 # Strip out cmake + the rapids packages, and save the combined environment
 cat merged.yml \
   | grep -v -P '^(.*?)\-(.*?)(rapids-build-env|rapids-notebook-env|rapids-doc-env|rapids-pytest-benchmark)(.*?)$' \
-  | grep -v -P '^(.*?)\-(.*?)(rmm|cudf|libraft|pyraft|pylibraft|raft-dask|dask-cudf|cugraph|cuspatial|cuxfilter)(.*?)$' \
+  | grep -v -P '^(.*?)\-(.*?)(rmm|cudf|libraft|pyraft|pylibraft|raft-dask|dask-cudf|cugraph|cuspatial|cuxfilter|cuml)(.*?)$' \
   | grep -v -P '^(.*?)\-(.*?)(\.git\@[^(main|master)])(.*?)$' \
   | grep -v -P '^(.*?)\-(.*?)(cmake=)(.*?)$' \
   > rapids.yml

--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -19,9 +19,6 @@ channels:
 - conda-forge
 - nvidia
 dependencies:
-- cmake>=3.20
-- cmake_setuptools
-- pytest-xdist
 - python=${PYTHON_VERSION}
 - pip:
   - debugpy

--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -26,17 +26,7 @@ EOF
 
 CUDA_TOOLKIT_VERSION=${CONDA_CUDA_TOOLKIT_VERSION:-$CUDA_SHORT_VERSION};
 
-find-env-file-version-old() {
-    ENVS_DIR="$RAPIDS_HOME/$1/conda/environments"
-    for YML in $ENVS_DIR/${1}_dev_cuda*.yml; do
-        YML="${YML#$ENVS_DIR/$1}"
-        YML="${YML#_dev_cuda}"
-        echo "${YML%*.yml}"
-        break;
-    done
-}
-
-find-env-file-version-new() {
+find-env-file-version() {
     # This function should be used for packages that have migrated to use
     # rapids-dependency-file-generator
 
@@ -53,30 +43,16 @@ find-env-file-version-new() {
     echo "${CONDA_ENV_CUDA_VER}"
 }
 
-replace-env-versions-old() {
-    CONDA_ENV_CUDA_VER=$(find-env-file-version-old $1)
-    cat "$RAPIDS_HOME/$1/conda/environments/$1_dev_cuda${CONDA_ENV_CUDA_VER}.yml" \
-  | sed -r "s/cuda-version=${CONDA_ENV_CUDA_VER}/cuda-version=${CUDA_TOOLKIT_VERSION}/g" \
-  | sed -r "s/cudatoolkit=${CONDA_ENV_CUDA_VER}/cudatoolkit=${CUDA_TOOLKIT_VERSION}/g" \
-  | sed -r "s/nvcc_linux-64=${CONDA_ENV_CUDA_VER}/nvcc_linux-64=${CUDA_TOOLKIT_VERSION}/g" \
-  | sed -r "s!rapidsai/label/cuda${CONDA_ENV_CUDA_VER}!rapidsai/label/cuda${CUDA_TOOLKIT_VERSION}!g" \
-  | sed -r "s/- python[<>=,\.0-9]*$/- python=${PYTHON_VERSION}/g"
-}
-
-replace-env-versions-new() {
+replace-env-versions() {
     # This function should be used for packages that have migrated to use
     # rapids-dependency-file-generator
-    CONDA_ENV_CUDA_VER=$(find-env-file-version-new $1)
+    CONDA_ENV_CUDA_VER=$(find-env-file-version $1)
     cat "${RAPIDS_HOME}/$1/conda/environments/all_cuda-${CONDA_ENV_CUDA_VER//./}_arch-x86_64.yaml" \
   | sed -r "s/cuda-version=${CONDA_ENV_CUDA_VER}/cuda-version=${CUDA_TOOLKIT_VERSION}/g" \
   | sed -r "s/cudatoolkit=${CONDA_ENV_CUDA_VER}/cudatoolkit=${CUDA_TOOLKIT_VERSION}/g" \
   | sed -r "s/nvcc_linux-64=${CONDA_ENV_CUDA_VER}/nvcc_linux-64=${CUDA_TOOLKIT_VERSION}/g" \
   | sed -r "s!rapidsai/label/cuda${CONDA_ENV_CUDA_VER}!rapidsai/label/cuda${CUDA_TOOLKIT_VERSION}!g" \
   | sed -r "s/- python[<>=,\.0-9]*$/- python=${PYTHON_VERSION}/g"
-}
-
-replace-env-versions() {
-    replace-env-versions-old $@ 2>/dev/null || replace-env-versions-new $@;
 }
 
 YMLS=()

--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -68,7 +68,7 @@ conda-merge ${YMLS[@]} > merged.yml
 # Strip out cmake + the rapids packages, and save the combined environment
 cat merged.yml \
   | grep -v -P '^(.*?)\-(.*?)(rapids-build-env|rapids-notebook-env|rapids-doc-env|rapids-pytest-benchmark)(.*?)$' \
-  | grep -v -P '^(.*?)\-(.*?)(rmm|cudf|libraft|pyraft|pylibraft|raft-dask|dask-cudf|cugraph|cuspatial|cuxfilter|cuml)(.*?)$' \
+  | grep -v -P '^(.*?)\-(.*?)(rmm|cudf|raft|cuml|cugraph|cuspatial|cuxfilter)(.*?)$' \
   | grep -v -P '^(.*?)\-(.*?)(\.git\@[^(main|master)])(.*?)$' \
   | grep -v -P '^(.*?)\-(.*?)(cmake=)(.*?)$' \
   > rapids.yml


### PR DESCRIPTION
This PR removes the pre-scikit-build function for building Python packages and the pre-dfg function for collecting dependencies from environment files. It also cleans up the list of packages to filter from the environment; previously cuml was being undesirably installed into the environment, which in turn pulled in its dependencies like raft and rmm.