### PR TITLE
Don't remove cumlprims or cugraph-ops.

### DIFF
--- a/etc/conda-merge.sh
+++ b/etc/conda-merge.sh
@@ -68,7 +68,7 @@ conda-merge ${YMLS[@]} > merged.yml
 # Strip out cmake + the rapids packages, and save the combined environment
 cat merged.yml \
   | grep -v -P '^(.*?)\-(.*?)(rapids-build-env|rapids-notebook-env|rapids-doc-env|rapids-pytest-benchmark)(.*?)$' \
-  | grep -v -P '^(.*?)\-(.*?)(rmm|cudf|raft|cuml|cugraph|cuspatial|cuxfilter)(.*?)$' \
+  | grep -v -P '^(.*?)\-(.*?)(rmm|cudf|raft|cuml(?!prims)|cugraph(?!ops)|cuspatial|cuxfilter)(.*?)$' \
   | grep -v -P '^(.*?)\-(.*?)(\.git\@[^(main|master)])(.*?)$' \
   | grep -v -P '^(.*?)\-(.*?)(cmake=)(.*?)$' \
   > rapids.yml


### PR DESCRIPTION
Fixes an issue from #95 where libcumlprims packages were being removed. cc: @vyasr I tested this and it works for me. I also did the same for `*cugraphops*` since those packages are effectively handled the same (private dependency of non-private package) even though we don't require installing those packages today.