### PR TITLE
Fix .bash_aliases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 **/etc/llvm
 **/etc/conda
 **/etc/.ccache
-**/etc/.bash_aliases
 **/etc/settings/.config/*
 **/etc/settings/.ipython/*
 **/etc/settings/.local/share/*
@@ -12,6 +11,7 @@
 **/etc/rapids/include/*
 **/etc/rapids/.vscode/*
 **/etc/rapids/rapids*.yml
+**/etc/rapids/.bash_aliases
 **/etc/rapids/.bash_history
 
 **/etc/notebooks/sandbox/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - &cugraph "${RAPIDS_HOME:-$PWD}/cugraph:${RAPIDS_HOME:-$PWD}/cugraph"
       - &cuspatial "${RAPIDS_HOME:-$PWD}/cuspatial:${RAPIDS_HOME:-$PWD}/cuspatial"
       - &bashrc "${COMPOSE_HOME:-$PWD/compose}/etc/rapids/.bashrc:${RAPIDS_HOME:-$PWD}/.bashrc"
+      - &bash_aliases "${COMPOSE_HOME:-$PWD/compose}/etc/rapids/.bash_aliases:${RAPIDS_HOME:-$PWD}/.bash_aliases"
       - &colornvcc "${COMPOSE_HOME:-$PWD/compose}/etc/rapids/colornvcc:/usr/local/bin/nvcc"
       - &dot_colornvccrc "${COMPOSE_HOME:-$PWD/compose}/etc/settings/.colornvccrc:${RAPIDS_HOME:-$PWD}/.colornvccrc"
       - &dot_local "${COMPOSE_HOME:-$PWD/compose}/etc/settings/.local:${RAPIDS_HOME:-$PWD}/.local"

--- a/etc/rapids/.bashrc
+++ b/etc/rapids/.bashrc
@@ -114,10 +114,6 @@ if [ -f ~/.bash_aliases ]; then
     . ~/.bash_aliases
 fi
 
-if [ -f "$COMPOSE_HOME/etc/.bash_aliases" ]; then
-    . "$COMPOSE_HOME/etc/.bash_aliases"
-fi
-
 # enable programmable completion features (you don't need to enable
 # this, if it's already enabled in /etc/bash.bashrc and /etc/profile
 # sources /etc/bash.bashrc).


### PR DESCRIPTION
This PR fixes support for custom `.bash_aliases` files. To add your own `.bash_aliases`, overwrite the empty file in `etc/rapids/.bash_aliases` and it will be picked up inside the container.