### PR TITLE
Fix test-raft-cpp.

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -843,7 +843,7 @@ test-cudf-java() {
 export -f test-cudf-java;
 
 test-raft-cpp() {
-    cd "$(find-cpp-build-home $RAFT_HOME)" && ./test_raft;
+    test-cpp "$(find-cpp-build-home $RAFT_HOME)" $@;
 }
 
 export -f test-raft-cpp;


### PR DESCRIPTION
This fixes the `test-raft-cpp` command. The previous command `./test_raft` doesn't seem to exist anymore.