### PR TITLE
Don't delete RMM's `_torch_allocator.cpp`

### DIFF
--- a/etc/bash-utils.sh
+++ b/etc/bash-utils.sh
@@ -651,7 +651,7 @@ clean-rmm-python() {
     find "$RMM_HOME" -type f -name '*.pyc' -delete;
     find "$RMM_HOME" -type d -name '__pycache__' -delete;
     find "$RMM_HOME/python" -type f -name '*.so' -delete;
-    find "$RMM_HOME/python" -type f -name '*.cpp' -delete;
+    find "$RMM_HOME/python" -type f -name '*.cpp' -not -name "_torch_allocator.cpp" -delete;
 }
 
 export -f clean-rmm-python;


### PR DESCRIPTION
The RMM Python source now contains a non-generated C++ file, `_torch_allocator.cpp`, from rapidsai/rmm#1407, so we need to avoid deleting it when cleaning rmm-python. This approach might not be the best if RMM Python goes on to include more C++ sources, but this fixes the clean / build process for now.